### PR TITLE
Restructure wrapper to fully support Scikit-Learn API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-- 3.7
-- 3.6
-- 3.5
+- 3.7.6
+- 3.6.10
+- 3.5.9
 install: pip install -U tox-travis tox-pip-version
 script: tox
 deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 scikit-learn>=0.21.0
-tensorflow>=2.2.0rc2
+tensorflow>=2.1.0

--- a/sklearn_keras_wrap/wrappers.py
+++ b/sklearn_keras_wrap/wrappers.py
@@ -1,355 +1,1064 @@
-# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
 """Wrapper for using the Scikit-Learn API with Keras models.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
+import warnings
+from collections import defaultdict, namedtuple
 import copy
-import types
 
 import numpy as np
 
-from tensorflow.python.keras import losses
-from tensorflow.python.keras.models import Sequential
+from tensorflow.python.keras.losses import is_categorical_crossentropy
+from tensorflow.python.keras import backend as K
+from tensorflow.python.keras.models import Model, Sequential, clone_model
+from tensorflow.python.keras.saving import saving_utils
+from tensorflow.python.keras.layers import serialize, deserialize
+from tensorflow.python.util import tf_inspect
 from tensorflow.python.keras.utils.generic_utils import has_arg
 from tensorflow.python.keras.utils.np_utils import to_categorical
 from tensorflow.python.util.tf_export import keras_export
 
 
-class BaseWrapper(object):
-  """Base class for the Keras scikit-learn wrapper.
+# namedtuple used for pickling Model instances
+SavedKerasModel = namedtuple(
+    "SavedKerasModel", "cls model training_config weights"
+)
 
-  Warning: This class should not be used directly.
-  Use descendant classes instead.
+# known keras function names that will be added to _legal_params_fns if they
+# exist in the generated model
+KNOWN_KERAS_FN_NAMES = (
+    "fit",
+    "evaluate",
+    "predict_classes",
+    "predict",
+)
 
-  Arguments:
-      build_fn: callable function or class instance
-      **sk_params: model parameters & fitting parameters
 
-  The `build_fn` should construct, compile and return a Keras model, which
-  will then be used to fit/predict. One of the following
-  three values could be passed to `build_fn`:
-  1. A function
-  2. An instance of a class that implements the `__call__` method
-  3. None. This means you implement a class that inherits from either
-  `KerasClassifier` or `KerasRegressor`. The `__call__` method of the
-  present class will then be treated as the default `build_fn`.
+def _merge_dicts(*args):
+    """Utility to merge multiple dictionaries last one wins style.
+    """
+    res = dict()
+    for arg in args:
+        res.update(arg)
+    return res
 
-  `sk_params` takes both model parameters and fitting parameters. Legal model
-  parameters are the arguments of `build_fn`. Note that like all other
-  estimators in scikit-learn, `build_fn` should provide default values for
-  its arguments, so that you could create the estimator without passing any
-  values to `sk_params`.
 
-  `sk_params` could also accept parameters for calling `fit`, `predict`,
-  `predict_proba`, and `score` methods (e.g., `epochs`, `batch_size`).
-  fitting (predicting) parameters are selected in the following order:
+def _check_array_sizes(y_true, y_pred, sample_weight):
+    """Array size checks for scoring functions.
+    """
+    if y_true.ndim == 1:
+        y_true = y_true.reshape(-1, 1)
+    if y_pred.ndim == 1:
+        y_pred = y_pred.reshape(-1, 1)
 
-  1. Values passed to the dictionary arguments of
-  `fit`, `predict`, `predict_proba`, and `score` methods
-  2. Values passed to `sk_params`
-  3. The default values of the `keras.models.Sequential`
-  `fit`, `predict`, `predict_proba` and `score` methods
+    if y_true.shape != y_pred.shape:
+        raise ValueError(
+            "Shape of `y_true` and `y_pred` did not match: %s != %s"
+            % (y_true.shape, y_pred.shape)
+        )
+    if sample_weight is not None:
+        if y_true.shape[0] != sample_weight.shape[0]:
+            raise ValueError(
+                "Shape of `y_true` and `sample_weight` did not match: %s != %s"
+                % (y_true.shape, sample_weight.shape)
+            )
+        if sample_weight.ndim != 1:
+            raise ValueError(
+                "`sample_weight` must be an array of shape (n_samples,)"
+            )
 
-  When using scikit-learn's `grid_search` API, legal tunable parameters are
-  those you could pass to `sk_params`, including fitting parameters.
-  In other words, you could use `grid_search` to search for the best
-  `batch_size` or `epochs` as well as the model parameters.
-  """
+    return y_true, y_pred, sample_weight
 
-  def __init__(self, build_fn=None, **sk_params):
-    self.build_fn = build_fn
-    self.sk_params = sk_params
-    self.check_params(sk_params)
 
-  def check_params(self, params):
-    """Checks for user typos in `params`.
+def _accuracy_score(y_true, y_pred, sample_weight=None, **kwargs):
+    """Accuracy score for classification functions.
+
+    Implementation borrowed from scikit-learn:
+    scikit-learn/scikit-learn/sklearn/metrics/_classification.py
+    """
+    y_true, y_pred, sample_weight = _check_array_sizes(
+        y_true, y_pred, sample_weight
+    )
+    # default cls_type is "multiclass"
+    cls_type = kwargs.get("cls_type", "multiclass")
+
+    if cls_type in ("multiclass", "binary"):
+        score = y_true == y_pred
+    if cls_type == "multilabel-indicator":
+        # need to manually compute this one
+        # pass kwargs since many arguments are shared
+        # classes_ should have shape (n_samples, n_outputs)
+        # compute accuracy like scikit-learn does,
+        # each row (categories each sample matched)
+        # must EXACTLY match between the prediction and truth ys
+        n_samples = y_true.shape[0]
+        if sample_weight is None:
+            sample_weight = np.ones(dtype=int, shape=(n_samples,))
+        differing_labels = np.count_nonzero(y_true - y_pred, axis=1)
+        score = differing_labels == 0
+    elif cls_type == "multiclass-multioutput":
+        # return the mean of the scores
+        # this is what scikit-learn does by default
+        score = np.mean(np.all(y_true == y_pred, axis=1))
+
+    return np.average(np.squeeze(score), weights=sample_weight)
+
+
+def _r2_score(y_true, y_pred, sample_weight=None, **kwargs):
+    """R^2 (coefficient of determination) regression score function.
+
+    Implementation borrowed from scikit-learn:
+    scikit-learn/scikit-learn/sklearn/metrics/_regression.py
+    """
+    y_true, y_pred, sample_weight = _check_array_sizes(
+        y_true, y_pred, sample_weight
+    )
+
+    if y_pred.shape[0] < 2:
+        msg = "R^2 score is not well-defined with less than two samples."
+        warnings.warn(msg)
+        return float("nan")
+
+    if sample_weight is not None:
+        weight = sample_weight[:, np.newaxis]
+    else:
+        weight = 1.0
+
+    numerator = (weight * (y_true - y_pred) ** 2).sum(axis=0, dtype=np.float64)
+    denominator = (
+        weight
+        * (y_true - np.average(y_true, axis=0, weights=sample_weight)) ** 2
+    ).sum(axis=0, dtype=np.float64)
+    nonzero_denominator = denominator != 0
+    nonzero_numerator = numerator != 0
+    valid_score = nonzero_denominator & nonzero_numerator
+    output_scores = np.ones([y_true.shape[1]])
+    output_scores[valid_score] = 1 - (
+        numerator[valid_score] / denominator[valid_score]
+    )
+    # arbitrary set to zero to avoid -inf scores, having a constant
+    # y_true is not interesting for scoring a regression anyway
+    output_scores[nonzero_numerator & ~nonzero_denominator] = 0.0
+
+    return np.average(output_scores)
+
+
+def _clone_prebuilt_model(build_fn):
+    """Clones and compiles a pre-built model when build_fn is an existing
+            Keras model instance.
 
     Arguments:
-        params: dictionary; the parameters to be checked
+        build_fn : instance of Keras Model.
 
-    Raises:
-        ValueError: if any member of `params` is not a valid argument.
+    Returns: copy of the input model with no training.
     """
-    legal_params_fns = [
-        Sequential.fit, Sequential.predict, Sequential.predict_classes,
-        Sequential.evaluate
+    model = clone_model(build_fn)
+    # clone_model does not compy over compilation parameters, do those manually
+    model_metadata = saving_utils.model_metadata(build_fn)
+    if "training_config" in model_metadata:
+        training_config = model_metadata["training_config"]
+    else:
+        raise ValueError(
+            "To use %s as `build_fn`, you must compile" "it first." % build_fn
+        )
+
+    model.compile(
+        **saving_utils.compile_args_from_training_config(training_config)
+    )
+
+    return model
+
+
+class BaseWrapper:
+    """Base class for the Keras scikit-learn wrapper.
+
+    Warning: This class should not be used directly.
+    Use descendant classes instead.
+
+    Arguments:
+        build_fn: callable function or class instance
+        **sk_params: model parameters & fitting parameters
+
+    The `build_fn` should construct, compile and return a Keras model, which
+    will then be used to fit/predict. One of the following
+    three values could be passed to `build_fn`:
+    1. A function
+    2. An instance of a class that implements the `__call__` method
+    3. An instance of a Keras Model. A copy of this instance will be made
+    4. None. This means you implement a class that inherits from `BaseWrapper`,
+    `KerasClassifier` or `KerasRegressor`. The `__call__` method of the
+    present class will then be treated as the default `build_fn`.
+    If `build_fn` has parameters X or y, these will be passed automatically.
+
+    `sk_params` takes both model parameters and fitting parameters. Legal model
+    parameters are the arguments of `build_fn`. Note that like all other
+    estimators in scikit-learn, `build_fn` or your child class should provide
+    default values for its arguments, so that you could create the estimator
+    without passing any values to `sk_params`.
+
+    `sk_params` could also accept parameters for calling `fit`, `predict`,
+    `predict_proba`, and `score` methods (e.g., `epochs`, `batch_size`).
+    fitting (predicting) parameters are selected in the following order:
+
+    1. Values passed to the dictionary arguments of
+    `fit`, `predict`, `predict_proba`, and `score` methods
+    2. Values passed to `sk_params`
+    3. The default values of the `keras.models.Sequential`
+    `fit`, `predict`, `predict_proba` and `score` methods
+
+    When using scikit-learn's `grid_search` API, legal tunable parameters are
+    those you could pass to `sk_params`, including fitting parameters.
+    In other words, you could use `grid_search` to search for the best
+    `batch_size` or `epochs` as well as the model parameters.
+    """
+
+    # basic legal parameter set, based on functions that will normally be
+    # called the model building function will be dynamically added
+    _legal_params_fns = [
+        Sequential.evaluate,
+        Sequential.fit,
+        Sequential.predict,
+        Model.evaluate,
+        Model.fit,
+        Model.predict,
     ]
-    if self.build_fn is None:
-      legal_params_fns.append(self.__call__)
-    elif (not isinstance(self.build_fn, types.FunctionType) and
-          not isinstance(self.build_fn, types.MethodType)):
-      legal_params_fns.append(self.build_fn.__call__)
-    else:
-      legal_params_fns.append(self.build_fn)
 
-    for params_name in params:
-      for fn in legal_params_fns:
-        if has_arg(fn, params_name):
-          break
-      else:
-        if params_name != 'nb_epoch':
-          raise ValueError('{} is not a legal parameter'.format(params_name))
+    model = None
 
-  def get_params(self, **params):  # pylint: disable=unused-argument
-    """Gets parameters for this estimator.
+    def __init__(self, build_fn=None, **sk_params):
 
-    Arguments:
-        **params: ignored (exists for API compatibility).
+        self.build_fn = build_fn
 
-    Returns:
-        Dictionary of parameter names mapped to their values.
-    """
-    res = copy.deepcopy(self.sk_params)
-    res.update({'build_fn': self.build_fn})
-    return res
+        # the sklearn API requires that all __init__ parameters be saved as an
+        # instance attribute of the same name
+        for name, val in sk_params.items():
+            setattr(self, name, val)
 
-  def set_params(self, **params):
-    """Sets the parameters of this estimator.
+        # collect all __init__ params for this base class as well as
+        # all child classes
+        init_params = []
+        # reverse the MRO, we want the 1st one to overwrite the nth
+        for clss_ in reversed(tf_inspect.getmro(self.__class__)):
+            if clss_ == object:
+                continue
+            argspec = tf_inspect.getfullargspec(clss_.__init__)
+            for p in argspec.args + argspec.kwonlyargs:
+                if p != "self":
+                    init_params.append(p)
 
-    Arguments:
-        **params: Dictionary of parameter names mapped to their values.
+        # add parameters from sk_params
+        self._init_params = set(init_params + list(sk_params.keys()))
 
-    Returns:
-        self
-    """
-    self.check_params(params)
-    self.sk_params.update(params)
-    return self
+        # check that all __init__ parameters were assigned (as per sklearn API)
+        for param in self._init_params:
+            if not hasattr(self, param):
+                raise RuntimeError("Parameter %s was not assigned")
 
-  def fit(self, x, y, **kwargs):
-    """Constructs a new model with `build_fn` & fit the model to `(x, y)`.
+        # determine what type of build_fn to use
+        self._check_build_fn(build_fn)
 
-    Arguments:
-        x : array-like, shape `(n_samples, n_features)`
-            Training samples where `n_samples` is the number of samples
-            and `n_features` is the number of features.
-        y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
-            True labels for `x`.
-        **kwargs: dictionary arguments
-            Legal arguments are the arguments of `Sequential.fit`
+        # check that all parameters correspond to a fit or model param
+        self._check_params(self.get_params(deep=False))
 
-    Returns:
-        history : object
-            details about the training history at each epoch.
-    """
-    if self.build_fn is None:
-      self.model = self.__call__(**self.filter_sk_params(self.__call__))
-    elif (not isinstance(self.build_fn, types.FunctionType) and
-          not isinstance(self.build_fn, types.MethodType)):
-      self.model = self.build_fn(
-          **self.filter_sk_params(self.build_fn.__call__))
-    else:
-      self.model = self.build_fn(**self.filter_sk_params(self.build_fn))
+    def _check_build_fn(self, build_fn):
+        """Checks `build_fn`.
 
-    if (losses.is_categorical_crossentropy(self.model.loss) and
-        len(y.shape) != 2):
-      y = to_categorical(y)
+        Arguments:
+            build_fn : method or callable class as defined in __init__
 
-    fit_args = copy.deepcopy(self.filter_sk_params(Sequential.fit))
-    fit_args.update(kwargs)
+        Raises:
+            ValueError: if `build_fn` is not valid.
+        """
+        if build_fn is None:
+            # no build_fn, use this class' __call__method
+            if not hasattr(self, "__call__"):
+                raise ValueError(
+                    "If not using the `build_fn` param, "
+                    "you must implement `__call__`"
+                )
+        elif isinstance(build_fn, Model):
+            # pre-built Keras model
+            self.__call__ = _clone_prebuilt_model
+        elif tf_inspect.isfunction(build_fn):
+            if hasattr(self, "__call__"):
+                raise ValueError(
+                    "This class cannot implement `__call__` if"
+                    "using the `build_fn` parameter"
+                )
+            # a callable method/function
+            self.__call__ = build_fn
+        elif (
+            callable(build_fn)
+            and hasattr(build_fn, "__class__")
+            and hasattr(build_fn.__class__, "__call__")
+        ):
+            if hasattr(self, "__call__"):
+                raise ValueError(
+                    "This class cannot implement `__call__` if"
+                    "using the `build_fn` parameter"
+                )
+            # an instance of a class implementing __call__
+            self.__call__ = build_fn.__call__
+        else:
+            raise ValueError("`build_fn` must be a callable or None")
+        # append legal parameters
+        self._legal_params_fns.append(self.__call__)
 
-    history = self.model.fit(x, y, **fit_args)
+    def _check_params(self, params):
+        """Checks for user typos in `params`.
 
-    return history
+        To disable, override this method in child class.
 
-  def filter_sk_params(self, fn, override=None):
-    """Filters `sk_params` and returns those in `fn`'s arguments.
+        Arguments:
+            params: dictionary; the parameters to be checked
 
-    Arguments:
-        fn : arbitrary function
-        override: dictionary, values to override `sk_params`
+        Raises:
+            ValueError: if any member of `params` is not a valid argument.
+        """
+        for param_name in params:
+            for fn in self._legal_params_fns:
+                if has_arg(fn, param_name) or param_name in self._init_params:
+                    break
+            else:
+                raise ValueError(
+                    "{} is not a legal parameter".format(param_name)
+                )
 
-    Returns:
-        res : dictionary containing variables
-            in both `sk_params` and `fn`'s arguments.
-    """
-    override = override or {}
-    res = {}
-    for name, value in self.sk_params.items():
-      if has_arg(fn, name):
-        res.update({name: value})
-    res.update(override)
-    return res
+    def _build_keras_model(self, X, y, sample_weight, **kwargs):
+        """Build the Keras model.
+
+        This method will process all arguments and call the model building
+        function with appropriate arguments.
+
+        Arguments:
+            X : array-like, shape `(n_samples, n_features)`
+                Training samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+            y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
+                True labels for `X`.
+            sample_weight : array-like of shape (n_samples,)
+                Sample weights. The Keras Model must support this.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments `build_fn`.
+        Returns:
+            self : object
+                a reference to the instance that can be chain called
+                (ex: instance.fit(X,y).transform(X) )
+        Raises:
+            ValuError : In case sample_weight != None and the Keras model's
+                `fit` method does not support that parameter.
+        """
+        # dynamically build model, i.e. self.__call__ builds a Keras model
+
+        # get model arguments
+        model_args = self._filter_params(self.__call__)
+
+        # add `sample_weight` param
+        # while it is not usually needed to build the model, some Keras models
+        # require knowledge of the type of sample_weight to be built.
+        sample_weight_arg = self._filter_params(
+            self.__call__, params_to_check={"sample_weight": sample_weight}
+        )
+
+        # check if the model building function requires X and/or y to be passed
+        X_y_args = self._filter_params(
+            self.__call__, params_to_check={"X": X, "y": y}
+        )
+
+        # filter kwargs
+        kwargs = self._filter_params(self.__call__, params_to_check=kwargs)
+
+        # combine all arguments
+        build_args = _merge_dicts(
+            model_args, X_y_args, sample_weight_arg, kwargs
+        )
+
+        # build model
+        model = self.__call__(**build_args)
+
+        # append legal parameter names from model
+        for known_keras_fn in KNOWN_KERAS_FN_NAMES:
+            if hasattr(model, known_keras_fn):
+                self._legal_params_fns.append(getattr(model, known_keras_fn))
+
+        return model
+
+    def _fit_keras_model(self, X, y, sample_weight, **kwargs):
+        """Fits the Keras model.
+
+        This method will process all arguments and call the Keras
+        model's `fit` method with approriate arguments.
+
+        Arguments:
+            X : array-like, shape `(n_samples, n_features)`
+                Training samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+            y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
+                True labels for `X`.
+            sample_weight : array-like of shape (n_samples,)
+                Sample weights. The Keras Model must support this.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments of the keras model's
+                `fit` method.
+        Returns:
+            self : object
+                a reference to the instance that can be chain called
+                (ex: instance.fit(X,y).transform(X) )
+        Raises:
+            ValuError : In case sample_weight != None and the Keras model's
+                        `fit` method does not support that parameter.
+        """
+        # add `sample_weight` param, required to be explicit by some sklearn
+        # functions that use inspect.signature on the `score` method
+        if sample_weight is not None:
+            # avoid pesky Keras warnings if sample_weight is not used
+            kwargs.update({"sample_weight": sample_weight})
+
+        # filter kwargs down to those accepted by self.model.fit
+        kwargs = self._filter_params(self.model.fit, params_to_check=kwargs)
+
+        if sample_weight is not None and "sample_weight" not in kwargs:
+            raise ValueError(
+                "Parameter `sample_weight` is unsupported by Keras model %s"
+                % self.model
+            )
+
+        # get model.fit's arguments (allows arbitrary model use)
+        fit_args = self._filter_params(self.model.fit)
+
+        # fit model and save history
+        # order implies kwargs overwrites fit_args
+        fit_args = _merge_dicts(fit_args, kwargs)
+
+        self.history = self.model.fit(x=X, y=y, **fit_args)
+
+        # return self to allow fit_transform and such to work
+        return self
+
+    def _check_output_model_compatibility(self, y):
+        """Checks that the model output number and y shape match, reshape as needed.
+        """
+        # check if this is a multi-output model
+        n_outputs = len(self.model.outputs)
+        if n_outputs != len(y):
+            raise RuntimeError(
+                "Detected a model with %s ouputs, but y has incompatible"
+                " shape %s" % (n_outputs, len(y))
+            )
+
+        # format y into the exact format that Keras expects
+        # this is the only format compatible with tf v1 and v2
+        if len(y) == 1:
+            y = y[0]
+        else:
+            y = tuple(np.squeeze(y_) for y_ in y)
+        return y
+
+    @staticmethod
+    def _pre_process_y(y):
+        """Handles manipulation of y inputs to fit or score.
+
+        By default, this just makes sure y is a numpy arrray.
+        Subclass and override this method to customize processing.
+
+        Arguments:
+            y : 1D or 2D numpy array, or iterable
+
+        Returns:
+            y : numpy array of shape (n_samples, n_ouputs)
+            extra_args : dictionary of output attributes, ex: n_outputs_
+                    These parameters are added to `self` by `fit` and
+                    consumed (but not reset) by `score`.
+        """
+        y = np.atleast_1d(y)
+        if y.ndim == 1:
+            y = np.reshape(y, (-1, 1))
+
+        extra_args = dict()
+
+        return y, extra_args
+
+    @staticmethod
+    def _post_process_y(y):
+        """Handles manipulation of predicted `y` values.
+
+        By default, it joins lists of predictions for multi-ouput models
+        into a single numpy array.
+        Subclass and override this method to customize processing.
+
+        Arguments:
+            y : 2D numpy array or list of numpy arrays
+                (the latter is for multi-ouput models)
+
+        Returns:
+            y : 2D numpy array with singular dimensions stripped
+            extra_args : attributes of output `y` such as probabilites.
+                Currently unused by KerasRegressor but kept for flexibility.
+        """
+        y = np.column_stack(y)
+
+        extra_args = dict()
+        return np.squeeze(y), extra_args
+
+    @staticmethod
+    def _pre_process_X(X):
+        """Handles manipulation of X before fitting.
+
+             Subclass and override this method to process X, for example
+             accomodate a multi-input model.
+
+        Arguments:
+            X : 2D numpy array
+
+        Returns:
+            X : unchanged 2D numpy array
+            extra_args : attributes of output `y` such as probabilites.
+                    Currently unused by KerasRegressor but kept for
+                    flexibility.
+        """
+        extra_args = dict()
+        return X, extra_args
+
+    def fit(self, X, y, sample_weight=None, **kwargs):
+        """Constructs a new model with `build_fn` & fit the model to `(X, y)`.
+
+        Arguments:
+            X : array-like, shape `(n_samples, n_features)`
+                Training samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+            y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
+                True labels for `X`.
+            sample_weight : array-like of shape (n_samples,), default=None
+                Sample weights. The Keras Model must support this.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments of the keras model's `fit`
+                method.
+        Returns:
+            self : object
+                a reference to the instance that can be chain called
+                (ex: instance.fit(X,y).transform(X) )
+        Raises:
+            ValueError : In case of invalid shape for `y` argument.
+            ValuError : In case sample_weight != None and the Keras model's
+                `fit` method does not support that parameter.
+        """
+
+        # pre process X, y
+        X, _ = self._pre_process_X(X)
+        y, extra_args = self._pre_process_y(y)
+        # update self.classes_, self.n_outputs_, self.n_classes_, self.cls_type
+        for attr_name, attr_val in extra_args.items():
+            setattr(self, attr_name, attr_val)
+
+        # build model
+        self.model = self._build_keras_model(
+            X, y, sample_weight=sample_weight, **kwargs
+        )
+
+        y = self._check_output_model_compatibility(y)
+
+        # fit model
+        return self._fit_keras_model(
+            X, y, sample_weight=sample_weight, **kwargs
+        )
+
+    def predict(self, X, **kwargs):
+        """Returns predictions for the given test data.
+
+        Arguments:
+            X: array-like, shape `(n_samples, n_features)`
+                Test samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+            sample_weight : array-like of shape (n_samples,), default=None
+                Sample weights. The Keras Model must support this.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments of `self.model.predict`.
+
+        Returns:
+            preds: array-like, shape `(n_samples,)`
+                Predictions.
+        """
+        # pre process X
+        X, _ = self._pre_process_X(X)
+
+        # filter kwargs and get attributes for predict
+        kwargs = self._filter_params(
+            self.model.predict, params_to_check=kwargs
+        )
+        predict_args = self._filter_params(self.model.predict)
+
+        # predict with Keras model
+        pred_args = _merge_dicts(predict_args, kwargs)
+        y_pred = self.model.predict(X, **pred_args)
+
+        # post process y
+        y, _ = self._post_process_y(y_pred)
+        return y
+
+    def score(self, X, y, sample_weight=None, **kwargs):
+        """Returns the mean accuracy on the given test data and labels.
+
+        Arguments:
+            X: array-like, shape `(n_samples, n_features)`
+                Test samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+            y: array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
+                True labels for `X`.
+            sample_weight : array-like of shape (n_samples,), default=None
+                Sample weights. The Keras Model must support this.
+            **kwargs: dictionary arguments
+                Legal arguments are those of self.model.evaluate.
+
+        Returns:
+            score: float
+                Mean accuracy of predictions on `X` wrt. `y`.
+
+        Raises:
+            ValueError: If the underlying model isn't configured to
+                compute accuracy. You should pass `metrics=["accuracy"]` to
+                the `.compile()` method of the model.
+        """
+        # pre process X, y
+        _, extra_args = self._pre_process_y(y)
+
+        # compute Keras model score
+        y_pred = self.predict(X, **kwargs)
+
+        return self._scorer(y, y_pred, sample_weight, **extra_args)
+
+    def _filter_params(self, fn, params_to_check=None):
+        """Filters all instance attributes (parameters) and
+             returns those in `fn`'s arguments.
+
+        Arguments:
+            fn : arbitrary function
+            params_to_check : dictionary, parameters to check.
+                Defaults to checking all attributes of this estimator.
+
+        Returns:
+            res : dictionary containing variables
+                in both self and `fn`'s arguments.
+        """
+        res = {}
+        for name, value in (params_to_check or self.__dict__).items():
+            if has_arg(fn, name):
+                res.update({name: value})
+        return res
+
+    def get_params(self, deep=True):
+        """Get parameters for this estimator.
+
+        This method mimics sklearn.base.BaseEstimator.get_params
+
+        Arguments:
+            deep : bool, default=True
+                If True, will return the parameters for this estimator and
+                contained subobjects that are estimators.
+
+        Returns:
+            params : mapping of string to any
+                Parameter names mapped to their values.
+        """
+        out = dict()
+        for key in self._init_params:
+            value = getattr(self, key)
+            if deep and hasattr(value, "get_params"):
+                deep_items = value.get_params().items()
+                out.update((key + "__" + k, val) for k, val in deep_items)
+            out[key] = value
+        return out
+
+    def set_params(self, **params):
+        """Set the parameters of this estimator.
+
+        The method works on simple estimators as well as on nested objects
+        (such as in sklearn Pipelines). The latter have parameters of the form
+        ``<component>__<parameter>`` so that it's possible to update each
+        component of a nested object.
+
+        This method mimics sklearn.base.BaseEstimator.set_params
+
+        Arguments:
+            **params : dict
+                Estimator parameters.
+        Returns:
+            self : object
+                Estimator instance.
+        """
+        if not params:
+            # Simple optimization to gain speed
+            return self
+        valid_params = self.get_params(deep=True)
+
+        nested_params = defaultdict(dict)  # grouped by prefix
+        for key, value in params.items():
+            key, delim, sub_key = key.partition("__")
+            if key not in valid_params:
+                raise ValueError(
+                    "Invalid parameter %s for estimator %s. "
+                    "Check the list of available parameters "
+                    "with `estimator.get_params().keys()`." % (key, self)
+                )
+            if delim:
+                nested_params[key][sub_key] = value
+            else:
+                setattr(self, key, value)
+                valid_params[key] = value
+
+        for key, sub_params in nested_params.items():
+            valid_params[key].set_params(**sub_params)
+
+        return self
+
+    def __getstate__(self):
+        """Get state of instance as a picklable/copyable dict.
+
+             Used by various scikit-learn methods to clone estimators. Also
+             used for pickling.
+             Because some objects (mainly Keras `Model` instances) are not
+             pickleable, it is necessary to iterate through all attributes
+             and clone the unpicklables manually.
+
+        Returns:
+            state : dictionary containing a copy of all attributes of this
+                    estimator with Keras Model instances being saved as
+                    HDF5 binary objects.
+        """
+
+        def _pack_obj(obj):
+            """Recursively packs objects.
+            """
+            try:
+                return copy.deepcopy(obj)
+            except TypeError:
+                pass  # is this a Keras serializable?
+            try:
+                model_metadata = saving_utils.model_metadata(obj)
+                training_config = model_metadata["training_config"]
+                model = serialize(obj)
+                weights = obj.get_weights()
+                return SavedKerasModel(
+                    cls=obj.__class__,
+                    model=model,
+                    weights=weights,
+                    training_config=training_config,
+                )
+            except (TypeError, AttributeError):
+                pass  # try manually packing the object
+            if hasattr(obj, "__dict__"):
+                for key, val in obj.__dict__.items():
+                    obj.__dict__[key] = _pack_obj(val)
+                return obj
+            if isinstance(obj, (list, tuple)):
+                obj_type = type(obj)
+                new_obj = obj_type([_pack_obj(o) for o in obj])
+                return new_obj
+
+            return obj
+
+        state = self.__dict__.copy()
+        for key, val in self.__dict__.items():
+            state[key] = _pack_obj(val)
+        return state
+
+    def __setstate__(self, state):
+        """Set state of live object from state saved via __getstate__.
+
+             Because some objects (mainly Keras `Model` instances) are not
+             pickleable, it is necessary to iterate through all attributes
+             and clone the unpicklables manually.
+
+        Arguments:
+            state : dict
+                dictionary from a previous call to `get_state` that will be
+                unpacked to this instance's `__dict__`.
+        """
+
+        def _unpack_obj(obj):
+            """Recursively unpacks objects.
+            """
+            if isinstance(obj, SavedKerasModel):
+                restored_model = deserialize(obj.model)
+                training_config = obj.training_config
+                restored_model.compile(
+                    **saving_utils.compile_args_from_training_config(
+                        training_config
+                    )
+                )
+                restored_model.set_weights(obj.weights)
+                return restored_model
+            if hasattr(obj, "__dict__"):
+                for key, val in obj.__dict__.items():
+                    obj.__dict__[key] = _unpack_obj(val)
+                return obj
+            if isinstance(obj, (list, tuple)):
+                obj_type = type(obj)
+                new_obj = obj_type([_unpack_obj(o) for o in obj])
+                return new_obj
+
+            return obj  # not much we can do at this point, cross fingers
+
+        for key, val in state.items():
+            setattr(self, key, _unpack_obj(val))
 
 
-@keras_export('keras.wrappers.scikit_learn.KerasClassifier')
+@keras_export("keras.wrappers.scikit_learn.KerasClassifier")
 class KerasClassifier(BaseWrapper):
-  """Implementation of the scikit-learn classifier API for Keras.
-  """
-
-  def fit(self, x, y, **kwargs):
-    """Constructs a new model with `build_fn` & fit the model to `(x, y)`.
-
-    Arguments:
-        x : array-like, shape `(n_samples, n_features)`
-            Training samples where `n_samples` is the number of samples
-            and `n_features` is the number of features.
-        y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
-            True labels for `x`.
-        **kwargs: dictionary arguments
-            Legal arguments are the arguments of `Sequential.fit`
-
-    Returns:
-        history : object
-            details about the training history at each epoch.
-
-    Raises:
-        ValueError: In case of invalid shape for `y` argument.
+    """Implementation of the scikit-learn classifier API for Keras.
     """
-    y = np.array(y)
-    if len(y.shape) == 2 and y.shape[1] > 1:
-      self.classes_ = np.arange(y.shape[1])
-    elif (len(y.shape) == 2 and y.shape[1] == 1) or len(y.shape) == 1:
-      self.classes_ = np.unique(y)
-      y = np.searchsorted(self.classes_, y)
-    else:
-      raise ValueError('Invalid shape for y: ' + str(y.shape))
-    self.n_classes_ = len(self.classes_)
-    return super(KerasClassifier, self).fit(x, y, **kwargs)
 
-  def predict(self, x, **kwargs):
-    """Returns the class predictions for the given test data.
+    _estimator_type = "classifier"
+    _scorer = staticmethod(_accuracy_score)
 
-    Arguments:
-        x: array-like, shape `(n_samples, n_features)`
-            Test samples where `n_samples` is the number of samples
-            and `n_features` is the number of features.
-        **kwargs: dictionary arguments
-            Legal arguments are the arguments
-            of `Sequential.predict_classes`.
+    @staticmethod
+    def _pre_process_y(y):
+        """Handles manipulation of y inputs to fit or score.
 
-    Returns:
-        preds: array-like, shape `(n_samples,)`
-            Class predictions.
-    """
-    kwargs = self.filter_sk_params(Sequential.predict_classes, kwargs)
-    classes = self.model.predict_classes(x, **kwargs)
-    return self.classes_[classes]
+             For KerasClassifier, this handles interpreting classes from `y`.
 
-  def predict_proba(self, x, **kwargs):
-    """Returns class probability estimates for the given test data.
+        Arguments:
+            y : 1D or 2D numpy array
 
-    Arguments:
-        x: array-like, shape `(n_samples, n_features)`
-            Test samples where `n_samples` is the number of samples
-            and `n_features` is the number of features.
-        **kwargs: dictionary arguments
-            Legal arguments are the arguments
-            of `Sequential.predict_classes`.
+        Returns:
+            y : modified 2D numpy array with 0 indexed integer class labels.
+            classes_ : list of original class labels.
+            n_classes_ : number of classes.
+            one_hot_encoded : True if input y was one-hot-encoded.
+        """
+        y, _ = super(KerasClassifier, KerasClassifier)._pre_process_y(y)
 
-    Returns:
-        proba: array-like, shape `(n_samples, n_outputs)`
-            Class probability estimates.
-            In the case of binary classification,
-            to match the scikit-learn API,
-            will return an array of shape `(n_samples, 2)`
-            (instead of `(n_sample, 1)` as in Keras).
-    """
-    kwargs = self.filter_sk_params(Sequential.predict_proba, kwargs)
-    probs = self.model.predict_proba(x, **kwargs)
+        if y.shape[1] == 1:
+            # single output
+            if np.unique(y).size == 2:
+                # y = array([1, 0, 1, 0]) or y = array(['used', 'new', 'used'])
+                cls_type = "binary"
+                # single task, single label, binary classification
+                classes_ = np.unique(y)
+                # convert to 0 indexed classes
+                y = np.searchsorted(classes_, y)
+                classes_ = [classes_]
+                y = [y]
+            elif np.unique(y).size > 2:
+                # y = array([1, 5, 2]) or
+                # y = array(['apple', 'orange', 'banana'])
+                cls_type = "multiclass"
+                classes_ = np.unique(y)
+                # convert to 0 indexed classes
+                y = np.searchsorted(classes_, y)
+                classes_ = [classes_]
+                y = [y]
+        elif y.shape[1] > 1:
+            # multi-output / multi-task
+            if np.unique(y).size == 2:
+                # y = array([1, 1, 1, 0], [0, 0, 1, 1])
+                cls_type = "multilabel-indicator"
+                # split into lists for multi-output Keras
+                # will be processed as multiple binary classifications
+                classes_ = [np.array([0, 1])] * y.shape[1]
+                y = np.split(y, y.shape[1], axis=1)
+            else:
+                # y = array(['apple', 0, 5], ['orange', 1, 3])
+                cls_type = "multiclass-multioutput"
+                # split into lists for multi-output Keras
+                # each will be processesed as a seperate multiclass problem
+                y = np.split(y, y.shape[1], axis=1)
+                classes_ = [np.unique(y_) for y_ in y]
 
-    # check if binary classification
-    if probs.shape[1] == 1:
-      # first column is probability of class 0 and second is of class 1
-      probs = np.hstack([1 - probs, probs])
-    return probs
+        if not classes_:
+            # other situations, such as 3 dimensional arrays, are not supported
+            raise ValueError("Invalid shape for y: " + str(y.shape))
 
-  def score(self, x, y, **kwargs):
-    """Returns the mean accuracy on the given test data and labels.
+        # self.classes_ is kept as an array when n_outputs==1 for compatibility
+        # with ensembles and other meta estimators
+        # which do not support multioutput
+        if len(classes_) == 1:
+            n_classes_ = classes_[0].size
+            classes_ = classes_[0]
+            n_outputs_ = 1
+        else:
+            n_classes_ = [class_.shape[0] for class_ in classes_]
+            n_outputs_ = len(classes_)
 
-    Arguments:
-        x: array-like, shape `(n_samples, n_features)`
-            Test samples where `n_samples` is the number of samples
-            and `n_features` is the number of features.
-        y: array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
-            True labels for `x`.
-        **kwargs: dictionary arguments
-            Legal arguments are the arguments of `Sequential.evaluate`.
+        extra_args = {
+            "classes_": classes_,
+            "n_outputs_": n_outputs_,
+            "n_classes_": n_classes_,
+            "cls_type": cls_type,
+        }
 
-    Returns:
-        score: float
-            Mean accuracy of predictions on `x` wrt. `y`.
+        return y, extra_args
 
-    Raises:
-        ValueError: If the underlying model isn't configured to
-            compute accuracy. You should pass `metrics=["accuracy"]` to
-            the `.compile()` method of the model.
-    """
-    y = np.searchsorted(self.classes_, y)
-    kwargs = self.filter_sk_params(Sequential.evaluate, kwargs)
+    def _post_process_y(self, y):
+        """Reverts _pre_process_inputs to return predicted probabilites
+             in formats sklearn likes as well as retrieving the original
+             classes.
+        """
+        if not isinstance(y, list):
+            # convert single-target y to a list for easier processing
+            y = [y]
 
-    loss_name = self.model.loss
-    if hasattr(loss_name, '__name__'):
-      loss_name = loss_name.__name__
-    if loss_name == 'categorical_crossentropy' and len(y.shape) != 2:
-      y = to_categorical(y)
+        # self.classes_ is kept as an array when n_outputs==1 for compatibility
+        # with meta estimators
+        if self.n_outputs_ == 1:
+            cls_ = [self.classes_]
+        else:
+            cls_ = self.classes_
 
-    outputs = self.model.evaluate(x, y, **kwargs)
-    if not isinstance(outputs, list):
-      outputs = [outputs]
-    for name, output in zip(self.model.metrics_names, outputs):
-      if name in ['accuracy', 'acc']:
-        return output
-    raise ValueError('The model is not configured to compute accuracy. '
-                     'You should pass `metrics=["accuracy"]` to '
-                     'the `model.compile()` method.')
+        y = copy.deepcopy(y)
+        cls_type = self.cls_type
+
+        class_predictions = []
+        for i, (y_, classes_) in enumerate(zip(y, cls_)):
+            if cls_type == "binary":
+                if y_.shape[1] == 1:
+                    class_predictions.append(
+                        classes_[np.where(y_ > 0.5, 1, 0)]
+                    )
+                    # first column is probability of class 0 and
+                    # second is of class 1
+                    y[i] = np.stack([1 - y_, y_], axis=1)
+                else:
+                    # array([0.9, 0.1], [.2, .8]) -> array(['yes', 'no'])
+                    class_predictions.append(
+                        classes_[np.argmax(np.where(y_ > 0.5, 1, 0), axis=1)]
+                    )
+            elif cls_type == "multiclass":
+                # array([0.8, 0.1, 0.1], [.1, .8, .1]) ->
+                # array(['apple', 'orange'])
+                class_predictions.append(classes_[np.argmax(y_, axis=1)])
+            elif cls_type == "multilabel-indicator":
+                class_predictions.append(np.where(y_ > 0.5, 1, 0))
+            elif cls_type == "multiclass-multioutput":
+                # array([0.9, 0.1], [.2, .8]) -> array(['apple', 'fruit'])
+                class_predictions.append(classes_[np.argmax(y_, axis=1)])
+            else:
+                raise ValueError(
+                    "Unknown classification task type '%s'" % cls_
+                )
+
+        class_probabilities = np.squeeze(np.column_stack(y))
+
+        y = np.squeeze(np.column_stack(class_predictions))
+
+        extra_args = {"class_probabilities": class_probabilities}
+
+        return y, extra_args
+
+    def _check_output_model_compatibility(self, y):
+        """Checks that the model output number and loss functions match y.
+        """
+        # check loss function to adjust the encoding of the input
+        # we need to do this to mimick scikit-learn behavior
+        if isinstance(self.model.loss, list):
+            losses = self.model.loss
+        else:
+            losses = [self.model.loss] * self.n_outputs_
+        for i, (loss, y_) in enumerate(zip(losses, y)):
+            if is_categorical_crossentropy(loss) and (
+                y_.ndim == 1 or y_.shape[1] == 1
+            ):
+                y[i] = to_categorical(y_)
+
+        return super()._check_output_model_compatibility(y)
+
+    def predict_proba(self, X, **kwargs):
+        """Returns class probability estimates for the given test data.
+
+        Arguments:
+            X: array-like, shape `(n_samples, n_features)`
+                Test samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments
+                of `Sequential.predict_classes`.
+
+        Returns:
+            proba: array-like, shape `(n_samples, n_outputs)`
+                Class probability estimates.
+                In the case of binary classification,
+                to match the scikit-learn API,
+                will return an array of shape `(n_samples, 2)`
+                (instead of `(n_sample, 1)` as in Keras).
+        """
+        # pre process X
+        X, _ = self._pre_process_X(X)
+
+        # filter kwargs and get attributes that are inputs to model.predict
+        kwargs = self._filter_params(
+            self.model.predict, params_to_check=kwargs
+        )
+        predict_args = self._filter_params(self.model.predict)
+
+        # call the Keras model
+        predict_args = _merge_dicts(predict_args, kwargs)
+        outputs = self.model.predict(X, **predict_args)
+
+        # join list of outputs into single output array
+        _, extra_args = self._post_process_y(outputs)
+
+        class_probabilities = extra_args["class_probabilities"]
+
+        return class_probabilities
 
 
-@keras_export('keras.wrappers.scikit_learn.KerasRegressor')
+@keras_export("keras.wrappers.scikit_learn.KerasRegressor")
 class KerasRegressor(BaseWrapper):
-  """Implementation of the scikit-learn regressor API for Keras.
-  """
-
-  def predict(self, x, **kwargs):
-    """Returns predictions for the given test data.
-
-    Arguments:
-        x: array-like, shape `(n_samples, n_features)`
-            Test samples where `n_samples` is the number of samples
-            and `n_features` is the number of features.
-        **kwargs: dictionary arguments
-            Legal arguments are the arguments of `Sequential.predict`.
-
-    Returns:
-        preds: array-like, shape `(n_samples,)`
-            Predictions.
+    """Implementation of the scikit-learn regressor API for Keras.
     """
-    kwargs = self.filter_sk_params(Sequential.predict, kwargs)
-    return np.squeeze(self.model.predict(x, **kwargs))
 
-  def score(self, x, y, **kwargs):
-    """Returns the mean loss on the given test data and labels.
+    _estimator_type = "regressor"
+    _scorer = staticmethod(_r2_score)
 
-    Arguments:
-        x: array-like, shape `(n_samples, n_features)`
-            Test samples where `n_samples` is the number of samples
-            and `n_features` is the number of features.
-        y: array-like, shape `(n_samples,)`
-            True labels for `x`.
-        **kwargs: dictionary arguments
-            Legal arguments are the arguments of `Sequential.evaluate`.
+    def _pre_process_y(self, y):
+        """Split y for multi-output tasks.
+        """
+        y, _ = super(KerasRegressor, self)._pre_process_y(y)
+        y = np.split(y, y.shape[1], axis=1)
 
-    Returns:
-        score: float
-            Mean accuracy of predictions on `x` wrt. `y`.
-    """
-    kwargs = self.filter_sk_params(Sequential.evaluate, kwargs)
-    loss = self.model.evaluate(x, y, **kwargs)
-    if isinstance(loss, list):
-      return -loss[0]
-    return -loss
+        n_outputs_ = len(y)
+
+        extra_args = {"n_outputs_": n_outputs_}
+
+        return y, extra_args
+
+    def score(self, X, y, sample_weight=None, **kwargs):
+        """Returns the mean loss on the given test data and labels.
+
+        Arguments:
+            X: array-like, shape `(n_samples, n_features)`
+                Test samples where `n_samples` is the number of samples
+                and `n_features` is the number of features.
+            y: array-like, shape `(n_samples,)`
+                True labels for `X`.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments of `Sequential.evaluate`.
+
+        Returns:
+            score: float
+                Mean accuracy of predictions on `X` wrt. `y`.
+        """
+        res = super(KerasRegressor, self).score(X, y, sample_weight, **kwargs)
+
+        # check loss function and warn if it is not the same as score function
+        if self.model.loss not in (
+            "mean_squared_error",
+            self.root_mean_squared_error,
+        ):
+            warnings.warn(
+                "R^2 is used to compute the score, it is advisable to use"
+                " a compatible loss function. This class provides an R^2"
+                " implementation in `KerasRegressor"
+                ".root_mean_squared_error`."
+            )
+
+        return res
+
+    @staticmethod
+    def root_mean_squared_error(y_true, y_pred):
+        """A simple Keras implementation of R^2 that can be used as a Keras
+             loss function.
+
+             Since `score` uses R^2, it is
+             advisable to use the same loss/metric when optimizing the model.
+        """
+        ss_res = K.sum(K.square(y_true - y_pred), axis=0)
+        ss_tot = K.sum(K.square(y_true - K.mean(y_true, axis=0)), axis=0)
+        return K.mean(1 - ss_res / (ss_tot + K.epsilon()), axis=-1)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,29 +1,52 @@
-# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
 """Tests for Scikit-learn API wrapper."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+
+import pickle
+
+from sklearn_keras_wrap import wrappers
+from sklearn_keras_wrap.wrappers import (
+    KerasClassifier,
+    KerasRegressor,
+    _r2_score,
+    _accuracy_score,
+)
+
+import pytest
 
 import numpy as np
 
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.datasets import load_boston, load_digits, load_iris
+from sklearn.ensemble import (
+    AdaBoostClassifier,
+    AdaBoostRegressor,
+    BaggingClassifier,
+    BaggingRegressor,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
+from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.neural_network import MLPClassifier
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.metrics import r2_score as sklearn_r2_score
+from sklearn.metrics import accuracy_score as sklearn_accuracy_score
+
+from tensorflow.python.framework.ops import convert_to_tensor
 from tensorflow.python import keras
 from tensorflow.python.keras import testing_utils
-from tensorflow.python.keras.wrappers import scikit_learn
-from tensorflow.python.platform import test
+from tensorflow.python.keras import backend as K
+from tensorflow.python.keras.layers import (
+    Concatenate,
+    Conv2D,
+    Dense,
+    Flatten,
+    Input,
+)
+from tensorflow.python.keras.models import Model, Sequential, clone_model
+from tensorflow.python.keras.utils.np_utils import to_categorical
+
 
 INPUT_DIM = 5
 HIDDEN_DIM = 5
@@ -35,157 +58,946 @@ EPOCHS = 1
 
 
 def build_fn_clf(hidden_dim):
-  model = keras.models.Sequential()
-  model.add(keras.layers.Dense(INPUT_DIM, input_shape=(INPUT_DIM,)))
-  model.add(keras.layers.Activation('relu'))
-  model.add(keras.layers.Dense(hidden_dim))
-  model.add(keras.layers.Activation('relu'))
-  model.add(keras.layers.Dense(NUM_CLASSES))
-  model.add(keras.layers.Activation('softmax'))
-  model.compile(
-      optimizer='sgd', loss='categorical_crossentropy', metrics=['accuracy'])
-  return model
+    """Builds a Sequential based classifier."""
+    model = keras.models.Sequential()
+    model.add(keras.layers.Dense(INPUT_DIM, input_shape=(INPUT_DIM,)))
+    model.add(keras.layers.Activation("relu"))
+    model.add(keras.layers.Dense(hidden_dim))
+    model.add(keras.layers.Activation("relu"))
+    model.add(keras.layers.Dense(NUM_CLASSES))
+    model.add(keras.layers.Activation("softmax"))
+    model.compile(
+        optimizer="sgd", loss="categorical_crossentropy", metrics=["accuracy"]
+    )
+    return model
 
 
 def assert_classification_works(clf):
-  np.random.seed(42)
-  (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
-      train_samples=TRAIN_SAMPLES,
-      test_samples=TEST_SAMPLES,
-      input_shape=(INPUT_DIM,),
-      num_classes=NUM_CLASSES)
+    """Checks a classification task for errors."""
+    np.random.seed(42)
+    (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
+        train_samples=TRAIN_SAMPLES,
+        test_samples=TEST_SAMPLES,
+        input_shape=(INPUT_DIM,),
+        num_classes=NUM_CLASSES,
+    )
 
-  clf.fit(x_train, y_train, batch_size=BATCH_SIZE, epochs=EPOCHS)
+    clf.fit(x_train, y_train, batch_size=BATCH_SIZE, epochs=EPOCHS)
 
-  score = clf.score(x_train, y_train, batch_size=BATCH_SIZE)
-  assert np.isscalar(score) and np.isfinite(score)
+    score = clf.score(x_train, y_train, batch_size=BATCH_SIZE)
+    assert np.isscalar(score) and np.isfinite(score)
 
-  preds = clf.predict(x_test, batch_size=BATCH_SIZE)
-  assert preds.shape == (TEST_SAMPLES,)
-  for prediction in np.unique(preds):
-    assert prediction in range(NUM_CLASSES)
+    preds = clf.predict(x_test, batch_size=BATCH_SIZE)
+    assert preds.shape == (TEST_SAMPLES,)
+    for prediction in np.unique(preds):
+        assert prediction in range(NUM_CLASSES)
 
-  proba = clf.predict_proba(x_test, batch_size=BATCH_SIZE)
-  assert proba.shape == (TEST_SAMPLES, NUM_CLASSES)
-  assert np.allclose(np.sum(proba, axis=1), np.ones(TEST_SAMPLES))
+    proba = clf.predict_proba(x_test, batch_size=BATCH_SIZE)
+    assert proba.shape == (TEST_SAMPLES, NUM_CLASSES)
+    assert np.allclose(np.sum(proba, axis=1), np.ones(TEST_SAMPLES))
 
 
 def build_fn_reg(hidden_dim):
-  model = keras.models.Sequential()
-  model.add(keras.layers.Dense(INPUT_DIM, input_shape=(INPUT_DIM,)))
-  model.add(keras.layers.Activation('relu'))
-  model.add(keras.layers.Dense(hidden_dim))
-  model.add(keras.layers.Activation('relu'))
-  model.add(keras.layers.Dense(1))
-  model.add(keras.layers.Activation('linear'))
-  model.compile(
-      optimizer='sgd', loss='mean_absolute_error', metrics=['accuracy'])
-  return model
+    """Builds a Sequential based regressor."""
+    model = keras.models.Sequential()
+    model.add(keras.layers.Dense(INPUT_DIM, input_shape=(INPUT_DIM,)))
+    model.add(keras.layers.Activation("relu"))
+    model.add(keras.layers.Dense(hidden_dim))
+    model.add(keras.layers.Activation("relu"))
+    model.add(keras.layers.Dense(1))
+    model.add(keras.layers.Activation("linear"))
+    model.compile(optimizer="sgd", loss="mean_absolute_error", metrics=["accuracy"])
+    return model
 
 
 def assert_regression_works(reg):
-  np.random.seed(42)
-  (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
-      train_samples=TRAIN_SAMPLES,
-      test_samples=TEST_SAMPLES,
-      input_shape=(INPUT_DIM,),
-      num_classes=NUM_CLASSES)
+    """Checks a regression task for errors."""
+    np.random.seed(42)
+    (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
+        train_samples=TRAIN_SAMPLES,
+        test_samples=TEST_SAMPLES,
+        input_shape=(INPUT_DIM,),
+        num_classes=NUM_CLASSES,
+    )
 
-  reg.fit(x_train, y_train, batch_size=BATCH_SIZE, epochs=EPOCHS)
+    reg.fit(x_train, y_train, batch_size=BATCH_SIZE, epochs=EPOCHS)
 
-  score = reg.score(x_train, y_train, batch_size=BATCH_SIZE)
-  assert np.isscalar(score) and np.isfinite(score)
+    score = reg.score(x_train, y_train, batch_size=BATCH_SIZE)
+    assert np.isscalar(score) and np.isfinite(score)
 
-  preds = reg.predict(x_test, batch_size=BATCH_SIZE)
-  assert preds.shape == (TEST_SAMPLES,)
+    preds = reg.predict(x_test, batch_size=BATCH_SIZE)
+    assert preds.shape == (TEST_SAMPLES,)
 
 
-class ScikitLearnAPIWrapperTest(test.TestCase):
+class TestScikitLearnAPIWrapper:
+    """Tests basic functionality."""
 
-  def test_classify_build_fn(self):
-    with self.cached_session():
-      clf = scikit_learn.KerasClassifier(
-          build_fn=build_fn_clf,
-          hidden_dim=HIDDEN_DIM,
-          batch_size=BATCH_SIZE,
-          epochs=EPOCHS)
+    def test_classify_build_fn(self):
+        """Tests a classification task for errors."""
+        clf = wrappers.KerasClassifier(
+            build_fn=build_fn_clf,
+            hidden_dim=HIDDEN_DIM,
+            batch_size=BATCH_SIZE,
+            epochs=EPOCHS,
+        )
 
-      assert_classification_works(clf)
+        assert_classification_works(clf)
 
-  def test_classify_class_build_fn(self):
+    def test_classify_class_build_fn(self):
+        """Tests for errors using a class implementing __call__."""
 
-    class ClassBuildFnClf(object):
+        class ClassBuildFnClf:
+            def __call__(self, hidden_dim):
+                return build_fn_clf(hidden_dim)
 
-      def __call__(self, hidden_dim):
+        clf = wrappers.KerasClassifier(
+            build_fn=ClassBuildFnClf(),
+            hidden_dim=HIDDEN_DIM,
+            batch_size=BATCH_SIZE,
+            epochs=EPOCHS,
+        )
+
+        assert_classification_works(clf)
+
+    def test_classify_inherit_class_build_fn(self):
+        """Tests for errors using an inherited class."""
+
+        class InheritClassBuildFnClf(wrappers.KerasClassifier):
+            def __call__(self, hidden_dim):
+                return build_fn_clf(hidden_dim)
+
+        clf = InheritClassBuildFnClf(
+            build_fn=None, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE, epochs=EPOCHS,
+        )
+
+        assert_classification_works(clf)
+
+    def test_regression_build_fn(self):
+        """Tests for errors using KerasRegressor."""
+        reg = wrappers.KerasRegressor(
+            build_fn=build_fn_reg,
+            hidden_dim=HIDDEN_DIM,
+            batch_size=BATCH_SIZE,
+            epochs=EPOCHS,
+        )
+
+        assert_regression_works(reg)
+
+    def test_regression_class_build_fn(self):
+        """Tests for errors using KerasRegressor implementing __call__."""
+
+        class ClassBuildFnReg:
+            def __call__(self, hidden_dim):
+                return build_fn_reg(hidden_dim)
+
+        reg = wrappers.KerasRegressor(
+            build_fn=ClassBuildFnReg(),
+            hidden_dim=HIDDEN_DIM,
+            batch_size=BATCH_SIZE,
+            epochs=EPOCHS,
+        )
+
+        assert_regression_works(reg)
+
+    def test_regression_inherit_class_build_fn(self):
+        """Tests for errors using KerasRegressor inherited."""
+
+        class InheritClassBuildFnReg(wrappers.KerasRegressor):
+            def __call__(self, hidden_dim):
+                return build_fn_reg(hidden_dim)
+
+        reg = InheritClassBuildFnReg(
+            build_fn=None, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE, epochs=EPOCHS,
+        )
+
+        assert_regression_works(reg)
+
+
+def load_digits8x8():
+    """Load image 8x8 dataset."""
+    data = load_digits()
+    data.data = data.data.reshape([data.data.shape[0], 1, 8, 8]) / 16.0
+    # Convert NCHW to NHWC
+    # Convert back to numpy or sklearn funcs (GridSearchCV, etc.) WILL fail
+    data.data = np.transpose(data.data, [0, 2, 3, 1])
+    K.set_image_data_format("channels_last")
+    return data
+
+
+def check(estimator, loader):
+    """Run basic checks (fit, score, pickle) on estimator."""
+    data = loader()
+    # limit to 100 data points to speed up testing
+    X, y = data.data[:100], data.target[:100]
+    estimator.fit(X, y)
+    estimator.predict(X)
+    score = estimator.score(X, y)
+    serialized_estimator = pickle.dumps(estimator)
+    deserialized_estimator = pickle.loads(serialized_estimator)
+    deserialized_estimator.predict(X)
+    score_new = deserialized_estimator.score(X, y)
+    np.testing.assert_almost_equal(score, score_new)
+    assert True
+
+
+def build_fn_regs(X, n_outputs_, hidden_layer_sizes=None, n_classes_=None):
+    """Dynamically build regressor."""
+    if hidden_layer_sizes is None:
+        hidden_layer_sizes = []
+    model = Sequential()
+    model.add(Dense(X.shape[1], activation="relu", input_shape=X.shape[1:]))
+    for size in hidden_layer_sizes:
+        model.add(Dense(size, activation="relu"))
+    model.add(Dense(n_outputs_))
+    model.compile("adam", loss="mean_squared_error")
+    return model
+
+
+def build_fn_clss(X, n_outputs_, hidden_layer_sizes=None, n_classes_=None):
+    """Dynamically build classifier."""
+    if hidden_layer_sizes is None:
+        hidden_layer_sizes = []
+    model = Sequential()
+    model.add(Dense(X.shape[1], activation="relu", input_shape=X.shape[1:]))
+    for size in hidden_layer_sizes:
+        model.add(Dense(size, activation="relu"))
+    model.add(Dense(1, activation="softmax"))
+    model.compile("adam", loss="binary_crossentropy", metrics=["accuracy"])
+    return model
+
+
+def build_fn_clscs(X, n_outputs_, hidden_layer_sizes=None, n_classes_=None):
+    """Dynamically build functional API regressor."""
+    if hidden_layer_sizes is None:
+        hidden_layer_sizes = []
+    model = Sequential()
+    model.add(Conv2D(3, (3, 3), input_shape=X.shape[1:]))
+    model.add(Flatten())
+    for size in hidden_layer_sizes:
+        model.add(Dense(size, activation="relu"))
+    model.add(Dense(n_classes_, activation="softmax"))
+    model.compile("adam", loss="categorical_crossentropy", metrics=["accuracy"])
+    return model
+
+
+def build_fn_clscf(X, n_outputs_, hidden_layer_sizes=None, n_classes_=None):
+    """Dynamically build functional API classifier."""
+    if hidden_layer_sizes is None:
+        hidden_layer_sizes = []
+    x = Input(shape=X.shape[1:])
+    z = Conv2D(3, (3, 3))(x)
+    z = Flatten()(z)
+    for size in hidden_layer_sizes:
+        z = Dense(size, activation="relu")(z)
+    y = Dense(n_classes_, activation="softmax")(z)
+    model = Model(inputs=x, outputs=y)
+    model.compile("adam", loss="categorical_crossentropy", metrics=["accuracy"])
+    return model
+
+
+CONFIG = {
+    "MLPRegressor": (
+        load_boston,
+        KerasRegressor,
+        build_fn_regs,
+        (BaggingRegressor, AdaBoostRegressor),
+    ),
+    "MLPClassifier": (
+        load_iris,
+        KerasClassifier,
+        build_fn_clss,
+        (BaggingClassifier, AdaBoostClassifier),
+    ),
+    "CNNClassifier": (
+        load_digits8x8,
+        KerasClassifier,
+        build_fn_clscs,
+        (BaggingClassifier, AdaBoostClassifier),
+    ),
+    "CNNClassifierF": (
+        load_digits8x8,
+        KerasClassifier,
+        build_fn_clscf,
+        (BaggingClassifier, AdaBoostClassifier),
+    ),
+}
+
+
+class TestScikitLearnAPIWrapperAdvFunc:
+    """Tests advanced features such as pipelines and hyperparameter tuning."""
+
+    def test_standalone(self):
+        """Tests standalone estimator."""
+        for config in [
+            "MLPRegressor",
+            "MLPClassifier",
+            "CNNClassifier",
+            "CNNClassifierF",
+        ]:
+            loader, model, build_fn, _ = CONFIG[config]
+            estimator = model(build_fn, epochs=1)
+            check(estimator, loader)
+
+    def test_pipeline(self):
+        """Tests compatibility with Scikit-learn's pipeline."""
+        for config in ["MLPRegressor", "MLPClassifier"]:
+            loader, model, build_fn, _ = CONFIG[config]
+            estimator = model(build_fn, epochs=1)
+            estimator = Pipeline([("s", StandardScaler()), ("e", estimator)])
+            check(estimator, loader)
+
+    @pytest.mark.slow
+    def test_searchcv(self):
+        """Tests compatibility with Scikit-learn's hyperparameter search CV."""
+        for config in [
+            "MLPRegressor",
+            "MLPClassifier",
+            "CNNClassifier",
+            "CNNClassifierF",
+        ]:
+            loader, model, build_fn, _ = CONFIG[config]
+            estimator = model(
+                build_fn, epochs=1, validation_split=0.1, hidden_layer_sizes=[]
+            )
+            check(
+                GridSearchCV(estimator, {"hidden_layer_sizes": [[], [5]]}), loader,
+            )
+            check(
+                RandomizedSearchCV(
+                    estimator, {"epochs": np.random.randint(1, 5, 2)}, n_iter=2,
+                ),
+                loader,
+            )
+
+    def test_ensemble(self):
+        """Tests compatibility with Scikit-learn's ensembles."""
+        for config in ["MLPRegressor", "MLPClassifier"]:
+            loader, model, build_fn, ensembles = CONFIG[config]
+            base_estimator = model(build_fn, epochs=1)
+            for ensemble in ensembles:
+                estimator = ensemble(base_estimator=base_estimator, n_estimators=2)
+                check(estimator, loader)
+
+    def test_calibratedclassifiercv(self):
+        """Tests compatibility with Scikit-learn's calibrated classifier CV."""
+        for config in ["MLPClassifier"]:
+            loader, _, build_fn, _ = CONFIG[config]
+            base_estimator = KerasClassifier(build_fn, epochs=1)
+            estimator = CalibratedClassifierCV(base_estimator=base_estimator, cv=5)
+            check(estimator, loader)
+
+
+class SentinalCallback(keras.callbacks.Callback):
+    """
+    Callback class that sets an internal value once it's been acessed.
+    """
+
+    called = 0
+
+    def on_train_begin(self, logs=None):
+        """Increments counter."""
+        self.called += 1
+
+
+class ClassWithCallback(wrappers.KerasClassifier):
+    """Must be defined at top level to be picklable.
+    """
+
+    def __init__(self, **sk_params):
+        self.callbacks = [SentinalCallback()]
+        super().__init__(**sk_params)
+
+    def __call__(self, hidden_dim):
         return build_fn_clf(hidden_dim)
 
-    with self.cached_session():
-      clf = scikit_learn.KerasClassifier(
-          build_fn=ClassBuildFnClf(),
-          hidden_dim=HIDDEN_DIM,
-          batch_size=BATCH_SIZE,
-          epochs=EPOCHS)
 
-      assert_classification_works(clf)
+class TestScikitLearnAPIWrapperCallbacks:
+    """Tests use of Callbacks."""
 
-  def test_classify_inherit_class_build_fn(self):
+    def test_callbacks_passed_as_arg(self):
+        """Tests estimators created passing a callback to __init__."""
+        for config in [
+            "MLPRegressor",
+            "MLPClassifier",
+            "CNNClassifier",
+            "CNNClassifierF",
+        ]:
+            loader, model, build_fn, _ = CONFIG[config]
+            callback = SentinalCallback()
+            estimator = model(build_fn, epochs=1, callbacks=[callback])
+            # check that callback did not break estimator
+            check(estimator, loader)
+            # check that callback is preserved after pickling
+            data = loader()
+            X, y = data.data[:100], data.target[:100]
+            estimator.fit(X, y)
+            assert estimator.callbacks[0].called != SentinalCallback.called
+            old_callback = estimator.callbacks[0]
+            deserialized_estimator = pickle.loads(pickle.dumps(estimator))
+            assert deserialized_estimator.callbacks[0].called == old_callback.called
 
-    class InheritClassBuildFnClf(scikit_learn.KerasClassifier):
+    def test_callbacks_inherit(self):
+        """Test estimators that inherit from KerasClassifier and implement
+        their own callbacks in their __init___.
+        """
+        clf = ClassWithCallback(
+            hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE, epochs=EPOCHS
+        )
 
-      def __call__(self, hidden_dim):
-        return build_fn_clf(hidden_dim)
-
-    with self.cached_session():
-      clf = InheritClassBuildFnClf(
-          build_fn=None,
-          hidden_dim=HIDDEN_DIM,
-          batch_size=BATCH_SIZE,
-          epochs=EPOCHS)
-
-      assert_classification_works(clf)
-
-  def test_regression_build_fn(self):
-    with self.cached_session():
-      reg = scikit_learn.KerasRegressor(
-          build_fn=build_fn_reg,
-          hidden_dim=HIDDEN_DIM,
-          batch_size=BATCH_SIZE,
-          epochs=EPOCHS)
-
-      assert_regression_works(reg)
-
-  def test_regression_class_build_fn(self):
-
-    class ClassBuildFnReg(object):
-
-      def __call__(self, hidden_dim):
-        return build_fn_reg(hidden_dim)
-
-    with self.cached_session():
-      reg = scikit_learn.KerasRegressor(
-          build_fn=ClassBuildFnReg(),
-          hidden_dim=HIDDEN_DIM,
-          batch_size=BATCH_SIZE,
-          epochs=EPOCHS)
-
-      assert_regression_works(reg)
-
-  def test_regression_inherit_class_build_fn(self):
-
-    class InheritClassBuildFnReg(scikit_learn.KerasRegressor):
-
-      def __call__(self, hidden_dim):
-        return build_fn_reg(hidden_dim)
-
-    with self.cached_session():
-      reg = InheritClassBuildFnReg(
-          build_fn=None,
-          hidden_dim=HIDDEN_DIM,
-          batch_size=BATCH_SIZE,
-          epochs=EPOCHS)
-
-      assert_regression_works(reg)
+        assert_classification_works(clf)
+        assert clf.callbacks[0].called != SentinalCallback.called
+        serialized_estimator = pickle.dumps(clf)
+        deserialized_estimator = pickle.loads(serialized_estimator)
+        assert deserialized_estimator.callbacks[0].called == clf.callbacks[0].called
+        assert_classification_works(deserialized_estimator)
 
 
-if __name__ == '__main__':
-  test.main()
+class TestScikitLearnAPIWrapperSampleWeights:
+    """Tests involving the sample_weight parameter.
+         TODO: fix warning regarding sample_weight shape coercing.
+    """
+
+    @staticmethod
+    def check_sample_weights_work(estimator):
+        """Checks that using the parameter sample_weight does not cause
+        issues (it does not check if the parameter actually works as intended).
+        """
+        (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
+            train_samples=TRAIN_SAMPLES,
+            test_samples=TEST_SAMPLES,
+            input_shape=(INPUT_DIM,),
+            num_classes=NUM_CLASSES,
+        )
+        s_w_train = np.random.randn(x_train.shape[0])
+
+        # check that we can train with sample weights
+        # TODO: how do we reliably check the effect of training with
+        # sample_weights?
+        estimator.fit(x_train, y_train, sample_weight=s_w_train)
+        estimator.predict(x_test)
+
+        # now train with no sample weights, test scoring
+        estimator.fit(x_train, y_train, sample_weight=None)
+        # re-use training data to try to get score > 0
+        score_n_w = estimator.score(x_train, y_train)
+        score_w = estimator.score(x_train, y_train, sample_weight=s_w_train)
+        # check that sample weights did *something*
+        try:
+            np.testing.assert_array_almost_equal(score_n_w, score_w)
+        except AssertionError:
+            return
+
+        raise AssertionError("`sample_weight` seemed to have no effect.")
+
+    def test_classify_build_fn(self):
+        clf = wrappers.KerasClassifier(
+            build_fn=build_fn_clf,
+            hidden_dim=HIDDEN_DIM,
+            batch_size=BATCH_SIZE,
+            epochs=EPOCHS,
+        )
+        self.check_sample_weights_work(clf)
+
+    def test_reg_build_fn(self):
+        clf = wrappers.KerasRegressor(
+            build_fn=build_fn_reg,
+            hidden_dim=HIDDEN_DIM,
+            batch_size=BATCH_SIZE,
+            epochs=EPOCHS,
+        )
+        self.check_sample_weights_work(clf)
+
+
+def dynamic_classifier(X, y, n_classes_):
+    """Creates a basic MLP classifier dynamically choosing binary/multiclass
+    classification loss and ouput activations.
+    """
+    n_features = X.shape[1]
+    if n_classes_ == 2:
+        # binary
+        loss = "binary_crossentropy"
+        output_activation = "sigmoid"
+        output_size = 1
+    else:
+        loss = "categorical_crossentropy"
+        output_activation = "softmax"
+        output_size = n_classes_
+    n_features = X.shape[1]
+    model = keras.models.Sequential()
+    model.add(keras.layers.Dense(n_features, input_shape=(n_features,)))
+    model.add(keras.layers.Activation("relu"))
+    model.add(keras.layers.Dense(100))
+    model.add(keras.layers.Activation("relu"))
+    model.add(keras.layers.Dense(output_size))
+    model.add(keras.layers.Activation(output_activation))
+    model.compile(optimizer="sgd", loss=loss, metrics=["accuracy"])
+    return model
+
+
+class TestScikitLearnAPIWrapperYShapes:
+    """Tests that compare output shapes to `MLPClassifier` from sklearn to
+         check that ouput shapes respect sklearn API.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.keras_clf = KerasClassifier(build_fn=dynamic_classifier)
+        cls.sklearn_clf = MLPClassifier()
+
+    def test_1d_multiclass(self):
+        """Compares KerasClassifier prediction output shape against
+        sklearn.neural_net.MPLClassifier for 1D multi-class (n_samples,).
+        """
+        # crate 1D multiclass labels
+        (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
+            train_samples=TRAIN_SAMPLES,
+            test_samples=TEST_SAMPLES,
+            input_shape=(INPUT_DIM,),
+            num_classes=4,
+        )
+        self.keras_clf.fit(X=x_train, y=y_train)
+        self.sklearn_clf.fit(X=x_train, y=y_train)
+        y_pred_keras = self.keras_clf.predict(X=x_test)
+        y_pred_sklearn = self.sklearn_clf.predict(X=x_test)
+        assert y_pred_keras.shape == y_pred_sklearn.shape
+        y_pred_prob_keras = self.keras_clf.predict_proba(X=x_test)
+        y_pred_prob_sklearn = self.sklearn_clf.predict_proba(X=x_test)
+        assert y_pred_prob_keras.shape == y_pred_prob_sklearn.shape
+
+    def test_2d_multiclass(self):
+        """Compares KerasClassifier prediction output shape against
+        sklearn.neural_net.MPLClassifier for 2D multi-class (n_samples,1).
+        """
+        # crate 2D multiclass labels
+        (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
+            train_samples=TRAIN_SAMPLES,
+            test_samples=TEST_SAMPLES,
+            input_shape=(INPUT_DIM,),
+            num_classes=4,
+        )
+        y_train = y_train.reshape(-1, 1)
+        self.keras_clf.fit(X=x_train, y=y_train)
+        self.sklearn_clf.fit(X=x_train, y=y_train)
+        y_pred_keras = self.keras_clf.predict(X=x_test)
+        y_pred_sklearn = self.sklearn_clf.predict(X=x_test)
+        assert y_pred_keras.shape == y_pred_sklearn.shape
+        y_pred_prob_keras = self.keras_clf.predict_proba(X=x_test)
+        y_pred_prob_sklearn = self.sklearn_clf.predict_proba(X=x_test)
+        assert y_pred_prob_keras.shape == y_pred_prob_sklearn.shape
+
+    def test_1d_binary(self):
+        """Compares KerasClassifier prediction output shape against
+        sklearn.neural_net.MPLClassifier for binary (n_samples,).
+        """
+        # create 1D binary labels
+        (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
+            train_samples=TRAIN_SAMPLES,
+            test_samples=TEST_SAMPLES,
+            input_shape=(INPUT_DIM,),
+            num_classes=2,
+        )
+        self.keras_clf.fit(X=x_train, y=y_train)
+        self.sklearn_clf.fit(X=x_train, y=y_train)
+        y_pred_keras = self.keras_clf.predict(X=x_test)
+        y_pred_sklearn = self.sklearn_clf.predict(X=x_test)
+        assert y_pred_keras.shape == y_pred_sklearn.shape
+        y_pred_prob_keras = self.keras_clf.predict_proba(X=x_test)
+        y_pred_prob_sklearn = self.sklearn_clf.predict_proba(X=x_test)
+        assert y_pred_prob_keras.shape == y_pred_prob_sklearn.shape
+
+    def test_2d_binary(self):
+        """Compares KerasClassifier prediction output shape against
+        sklearn.neural_net.MPLClassifier for 2D binary (n_samples,1).
+        """
+        # create 2D binary labels
+        (x_train, y_train), (x_test, _) = testing_utils.get_test_data(
+            train_samples=TRAIN_SAMPLES,
+            test_samples=TEST_SAMPLES,
+            input_shape=(INPUT_DIM,),
+            num_classes=2,
+        )
+        y_train = y_train.reshape(-1, 1)
+        self.keras_clf.fit(X=x_train, y=y_train)
+        self.sklearn_clf.fit(X=x_train, y=y_train)
+        y_pred_keras = self.keras_clf.predict(X=x_test)
+        y_pred_sklearn = self.sklearn_clf.predict(X=x_test)
+        assert y_pred_keras.shape == y_pred_sklearn.shape
+        y_pred_prob_keras = self.keras_clf.predict_proba(X=x_test)
+        y_pred_prob_sklearn = self.sklearn_clf.predict_proba(X=x_test)
+        assert y_pred_prob_keras.shape == y_pred_prob_sklearn.shape
+
+
+class TestScikitLearnAPIWrapperPrebuiltModel:
+    """Tests using a prebuilt model instance."""
+
+    def test_prebuilt_model(self):
+        """Tests using a prebuilt model."""
+        for config in [
+            "MLPRegressor",
+            "MLPClassifier",
+            "CNNClassifier",
+            "CNNClassifierF",
+        ]:
+            loader, model, build_fn, _ = CONFIG[config]
+            data = loader()
+            x_train, y_train = data.data[:100], data.target[:100]
+
+            n_classes_ = np.unique(y_train).size
+            # make y the same shape as will be used by .fit
+            if config != "MLPRegressor":
+                y_train = to_categorical(y_train)
+                keras_model = build_fn(X=x_train, n_classes_=n_classes_, n_outputs_=1)
+            else:
+                keras_model = build_fn(X=x_train, n_outputs_=1)
+
+            estimator = model(build_fn=keras_model)
+            check(estimator, loader)
+
+    def test_uncompiled_prebuilt_model_raises_error(self):
+        """Tests that an uncompiled model cannot be used as build_fn param."""
+
+        for config in [
+            "MLPRegressor",
+            "MLPClassifier",
+            "CNNClassifier",
+            "CNNClassifierF",
+        ]:
+            loader, model, build_fn, _ = CONFIG[config]
+            data = loader()
+            x_train, y_train = data.data[:100], data.target[:100]
+
+            n_classes_ = np.unique(y_train).size
+            # make y the same shape as will be used by .fit
+            if config != "MLPRegressor":
+                y_train = to_categorical(y_train)
+                keras_model = build_fn(X=x_train, n_classes_=n_classes_, n_outputs_=1)
+            else:
+                keras_model = build_fn(X=x_train, n_outputs_=1)
+
+            # clone to simulate uncompiled model
+            keras_model = clone_model(keras_model)
+            estimator = model(build_fn=keras_model)
+            with pytest.raises(ValueError):
+                check(estimator, loader)
+
+
+class FunctionAPIMultiInputMultiOutputClassifier(KerasClassifier):
+    """Tests Functional API Classifier with 2 inputs and 2 outputs
+    """
+
+    def __call__(self, X, n_classes_):
+        inp1 = Input((1,))
+        inp2 = Input((3,))
+
+        x1 = Dense(100)(inp1)
+        x2 = Dense(100)(inp2)
+
+        x3 = Concatenate(axis=-1)([x1, x2])
+
+        binary_out = Dense(1, activation="sigmoid")(x3)
+        cat_out = Dense(n_classes_[1], activation="softmax")(x3)
+
+        model = Model([inp1, inp2], [binary_out, cat_out])
+        losses = ["binary_crossentropy", "categorical_crossentropy"]
+        model.compile(optimizer="adam", loss=losses, metrics=["accuracy"])
+
+        return model
+
+    @staticmethod
+    def _pre_process_X(X):
+        """To support multiple inputs, a custom method must be defined.
+        """
+        return [(X[:, 0], X[:, 1:4])], dict()
+
+
+class FunctionAPIMultiLabelClassifier(KerasClassifier):
+    """Tests Functional API Classifier with 2 inputs and 2 outputs
+    """
+
+    def __call__(self, X, n_outputs_):
+        inp = Input((4,))
+
+        x1 = Dense(100)(inp)
+
+        outputs = []
+        for _ in range(n_outputs_):
+            # simulate multiple binary classification outputs
+            # in reality, these would come from different nodes
+            outputs.append(Dense(1, activation="sigmoid")(x1))
+
+        model = Model(inp, outputs)
+        losses = "binary_crossentropy"
+        model.compile(optimizer="adam", loss=losses, metrics=["accuracy"])
+
+        return model
+
+
+class FunctionAPIMultiOutputRegressor(KerasRegressor):
+    """Tests Functional API Regressor with multiple outputs.
+    """
+
+    def __call__(self, X, n_outputs_):
+        inp = Input((INPUT_DIM,))
+
+        x1 = Dense(100)(inp)
+
+        outputs = []
+        for _ in range(n_outputs_):
+            # simulate multiple binary classification outputs
+            # in reality, these would come from different nodes
+            outputs.append(Dense(1)(x1))
+
+        model = Model([inp], outputs)
+        losses = "mean_squared_error"
+        model.compile(optimizer="adam", loss=losses, metrics=["mse"])
+
+        return model
+
+
+@keras.utils.generic_utils.register_keras_serializable()
+class CustomLoss(keras.losses.MeanSquaredError):
+    """Dummy custom loss."""
+
+
+@keras.utils.generic_utils.register_keras_serializable()
+class CustomModelRegistered(Model):
+    """Dummy custom Model subclass that is registered to be serializable."""
+
+
+class CustomModelUnregistered(Model):
+    """Dummy custom Model subclass that is not registered to be
+    serializable."""
+
+
+def build_fn_regs_custom_loss(X, n_outputs_, hidden_layer_sizes=None):
+    """Build regressor with subclassed loss function."""
+    if hidden_layer_sizes is None:
+        hidden_layer_sizes = []
+    model = Sequential()
+    model.add(Dense(X.shape[1], activation="relu", input_shape=X.shape[1:]))
+    for size in hidden_layer_sizes:
+        model.add(Dense(size, activation="relu"))
+    model.add(Dense(n_outputs_))
+    model.compile("adam", loss=CustomLoss())
+    return model
+
+
+def build_fn_regs_custom_model_reg(X, n_outputs_, hidden_layer_sizes=None):
+    """Build regressor with subclassed Model registered as serializable."""
+    if hidden_layer_sizes is None:
+        hidden_layer_sizes = []
+    x = Input(shape=X.shape[1])
+    z = Dense(X.shape[1], activation="relu")(x)
+    for size in hidden_layer_sizes:
+        z = Dense(size, activation="relu")(z)
+    y = Dense(n_outputs_, activation="linear")(z)
+    model = CustomModelRegistered(inputs=x, outputs=y)
+    model.compile("adam", loss="mean_squared_error")
+    return model
+
+
+def build_fn_regs_custom_model_unreg(X, n_outputs_, hidden_layer_sizes=None):
+    """Build regressor with subclassed Model not registered as serializable."""
+    if hidden_layer_sizes is None:
+        hidden_layer_sizes = []
+    x = Input(shape=X.shape[1])
+    z = Dense(X.shape[1], activation="relu")(x)
+    for size in hidden_layer_sizes:
+        z = Dense(size, activation="relu")(z)
+    y = Dense(n_outputs_, activation="linear")(z)
+    model = CustomModelUnregistered(inputs=x, outputs=y)
+    model.compile("adam", loss="mean_squared_error")
+    return model
+
+
+class TestSerializeCustomLayers:
+    """Tests serializing custom layers."""
+
+    def test_custom_loss_function(self):
+        """Test that a registered subclassed Model can be serialized."""
+        estimator = KerasRegressor(build_fn=build_fn_regs_custom_loss)
+        check(estimator, load_boston)
+
+    def test_custom_model_registered(self):
+        """Test that a registered subclassed loss function can be
+        serialized."""
+        estimator = KerasRegressor(build_fn=build_fn_regs_custom_model_reg)
+        check(estimator, load_boston)
+
+    def test_custom_model_unregistered(self):
+        """Test that an unregistered subclassed Model raises an error."""
+        estimator = KerasRegressor(build_fn=build_fn_regs_custom_model_unreg)
+        with pytest.raises(ValueError):
+            check(estimator, load_boston)
+
+
+class TestScikitLearnAPIWrapperScoring:
+    """Tests scoring methods.
+    """
+
+    def test_scoring_r2(self):
+        """Test custom R^2 implementation against scikit-learn's."""
+        n_samples = 50
+
+        datasets = []
+        y_true = np.arange(n_samples, dtype=float)
+        y_pred = y_true + 1
+        datasets.append((y_true.reshape(-1, 1), y_pred.reshape(-1, 1)))
+        y_true = np.random.random_sample(size=y_true.shape)
+        y_pred = np.random.random_sample(size=y_true.shape)
+        datasets.append((y_true.reshape(-1, 1), y_pred.reshape(-1, 1)))
+
+        def keras_backend_r2(y_true, y_pred):
+            """Wrap Keras operations to numpy."""
+            y_true = convert_to_tensor(y_true)
+            y_pred = convert_to_tensor(y_pred)
+            return KerasRegressor.root_mean_squared_error(y_true, y_pred).numpy()
+
+        score_functions = (
+            _r2_score,
+            keras_backend_r2,
+        )
+        correct_scorer = sklearn_r2_score
+
+        for (y_true, y_pred) in datasets:
+            for f in score_functions:
+                np.testing.assert_almost_equal(
+                    f(y_true, y_pred), correct_scorer(y_true, y_pred), decimal=5,
+                )
+
+    def test_scoring_accuracy(self):
+        """Test custom accuracy implementation against scikit-learn's."""
+
+        n_samples = 50
+
+        def make_multiclass(y):
+            return y.reshape(-1, 1)
+
+        datasets = []
+        y_true = np.random.randint(low=0, high=n_samples, size=n_samples)
+        y_pred = np.random.randint(low=0, high=n_samples, size=n_samples)
+        datasets.append((make_multiclass(y_true), make_multiclass(y_pred)))
+        score_functions = (_accuracy_score,)
+        correct_scorer = sklearn_accuracy_score
+
+        for (y_true, y_pred) in datasets:
+            for f in score_functions:
+                np.testing.assert_almost_equal(
+                    f(y_true, y_pred), correct_scorer(y_true, y_pred), decimal=5,
+                )
+
+    def test_scoring_accuracy_multilabel(self):
+        """Test that accuracy score function works for multilabel ouputs."""
+        n_samples = 50
+        n_outputs = 5
+        n_classes = 2
+
+        def make_multilabel(y):
+            return np.repeat(y.reshape(-1, 1), n_outputs, axis=1)
+
+        datasets = []
+        y_true = np.random.randint(low=0, high=n_classes, size=n_samples)
+        y_pred = np.random.randint(low=0, high=n_classes, size=n_samples)
+        datasets.append((make_multilabel(y_true), make_multilabel(y_pred)))
+        score_functions = (_accuracy_score,)
+        correct_scorer = sklearn_accuracy_score
+
+        for (y_true, y_pred) in datasets:
+            for f in score_functions:
+                np.testing.assert_almost_equal(
+                    f(y_true, y_pred), correct_scorer(y_true, y_pred), decimal=5,
+                )
+
+    def test_scoring_accuracy_multiclass_multioutput(self):
+        """Test that accuracy score function works for multioutput ouputs."""
+        n_samples = 50
+        n_outputs = 5
+        n_classes = 10
+
+        def make_multioutput(y):
+            return np.repeat(y.reshape(-1, 1), n_outputs, axis=1)
+
+        datasets = []
+        y_true = np.random.randint(low=0, high=n_classes, size=n_samples)
+        y_pred = np.random.randint(low=0, high=n_classes, size=n_samples)
+        datasets.append((make_multioutput(y_true), make_multioutput(y_pred)))
+        score_functions = (
+            lambda y1, y2: _accuracy_score(y1, y2, cls_type="multiclass-multioutput"),
+        )
+
+        def correct_scorer(y1, y2):
+            return np.mean(np.all(y1 == y2, axis=1))
+
+        for (y_true, y_pred) in datasets:
+            for f in score_functions:
+                np.testing.assert_almost_equal(
+                    f(y_true, y_pred), correct_scorer(y_true, y_pred), decimal=5,
+                )
+
+
+class TestScikitLearnAPIWrapperMultiInputOutput:
+    """Tests involving multiple inputs / outputs.
+    """
+
+    def test_multi_input_and_output(self):
+        """Compares to the scikit-learn RandomForestRegressor classifier.
+        """
+        clf = FunctionAPIMultiInputMultiOutputClassifier()
+        (x_train, y_train), (x_test, y_test) = testing_utils.get_test_data(
+            train_samples=TRAIN_SAMPLES,
+            test_samples=TEST_SAMPLES,
+            input_shape=(4,),
+            num_classes=3,
+        )
+        y_train = np.stack([y_train == 1, y_train], axis=1)  # simulate 2 outputs
+        y_test = np.stack([y_test == 1, y_test], axis=1)  # simulate 2 outputs
+        clf.fit(x_train, y_train)
+        clf.predict(x_test)
+        clf.score(x_train, y_train)
+
+    def test_multi_label_clasification(self):
+        """Compares to the scikit-learn RandomForestRegressor classifier.
+        """
+        clf_keras = FunctionAPIMultiLabelClassifier()
+        clf_sklearn = RandomForestClassifier()
+        # taken from https://scikit-learn.org/stable/modules/multiclass.html
+        y = np.array([[2, 3, 4], [2], [0, 1, 3], [0, 1, 2, 3, 4], [0, 1, 2]])
+        y = MultiLabelBinarizer().fit_transform(y)
+
+        (x_train, _), (_, _) = testing_utils.get_test_data(
+            train_samples=y.shape[0], test_samples=0, input_shape=(4,), num_classes=3,
+        )
+
+        clf_keras.fit(x_train, y)
+        y_pred_keras = clf_keras.predict(x_train)
+        clf_keras.score(x_train, y)
+
+        clf_sklearn.fit(x_train, y)
+        y_pred_sklearn = clf_sklearn.predict(x_train)
+        clf_sklearn.score(x_train, y)
+
+        assert y_pred_keras.shape == y_pred_sklearn.shape
+
+    def test_multi_output_regression(self):
+        """Compares to the scikit-learn RandomForestRegressor classifier.
+        """
+        reg_keras = FunctionAPIMultiOutputRegressor()
+        reg_sklearn = RandomForestRegressor()
+        # taken from https://scikit-learn.org/stable/modules/multiclass.html
+        (X, _), (_, _) = testing_utils.get_test_data(
+            train_samples=TRAIN_SAMPLES,
+            test_samples=TEST_SAMPLES,
+            input_shape=(INPUT_DIM,),
+            num_classes=NUM_CLASSES,
+        )
+        y = np.random.random_sample(size=(TRAIN_SAMPLES, NUM_CLASSES))
+
+        reg_keras.fit(X, y)
+        y_pred_keras = reg_keras.predict(X)
+        reg_keras.score(X, y)
+
+        reg_sklearn.fit(X, y)
+        y_pred_sklearn = reg_sklearn.predict(X)
+        reg_sklearn.score(X, y)
+
+        assert y_pred_keras.shape == y_pred_sklearn.shape


### PR DESCRIPTION
- Restructure wrapper to fully support Scikit-Learn API
- Deprecate Python 2 since this is now an external package
- Move tests to Pytest