### PR TITLE
Add extensive tests from scikit-learn test suite

### DIFF
--- a/sklearn_keras_wrap/wrappers.py
+++ b/sklearn_keras_wrap/wrappers.py
@@ -11,7 +11,9 @@ from sklearn.metrics import accuracy_score as sklearn_accuracy_score
 from sklearn.metrics import r2_score as sklearn_r2_score
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import (
-    check_X_y, check_array, _check_sample_weight
+    check_X_y,
+    check_array,
+    _check_sample_weight,
 )
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras.layers import deserialize, serialize
@@ -19,7 +21,8 @@ from tensorflow.python.keras.losses import is_categorical_crossentropy
 from tensorflow.python.keras.models import Model, Sequential, clone_model
 from tensorflow.python.keras.saving import saving_utils
 from tensorflow.python.keras.utils.generic_utils import (
-    has_arg, register_keras_serializable
+    has_arg,
+    register_keras_serializable,
 )
 from tensorflow.python.keras.utils.np_utils import to_categorical
 
@@ -44,20 +47,20 @@ ARGS_KWARGS_IDENTIFIERS = (
 )
 
 _DEFAULT_TAGS = {
-    'non_deterministic': True,  # can't easily set random_state
-    'requires_positive_X': False,
-    'requires_positive_y': False,
-    'X_types': ['2darray'],
-    'poor_score': True,
-    'no_validation': False,
-    'multioutput': True,
+    "non_deterministic": True,  # can't easily set random_state
+    "requires_positive_X": False,
+    "requires_positive_y": False,
+    "X_types": ["2darray"],
+    "poor_score": True,
+    "no_validation": False,
+    "multioutput": True,
     "allow_nan": False,
-    'stateless': False,
-    'multilabel': False,
-    '_skip_test': False,
-    'multioutput_only': False,
-    'binary_only': False,
-    'requires_fit': True
+    "stateless": False,
+    "multilabel": False,
+    "_skip_test": False,
+    "multioutput_only": False,
+    "binary_only": False,
+    "requires_fit": True,
 }
 
 
@@ -435,17 +438,17 @@ class BaseWrapper:
         """
         # basic checks
         X, y = check_X_y(
-            X, y,
+            X,
+            y,
             allow_nd=True,  # allow X to have more than 2 dimensions
             multi_output=True,  # allow y to be 2D
         )
 
-        X = check_array(X, allow_nd=True, dtype=['float64', 'int'])
+        X = check_array(X, allow_nd=True, dtype=["float64", "int"])
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X,
-                dtype=['float64', 'int']
+                sample_weight, X, dtype=["float64", "int"]
             )
 
         # pre process X, y
@@ -490,7 +493,7 @@ class BaseWrapper:
             )
 
         # basic input checks
-        X = check_array(X, allow_nd=True, dtype=['float64', 'int'])
+        X = check_array(X, allow_nd=True, dtype=["float64", "int"])
 
         # pre process X
         X, _ = self._pre_process_X(X)
@@ -535,8 +538,7 @@ class BaseWrapper:
         # validate sample weights
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X,
-                dtype=['float64', 'int']
+                sample_weight, X, dtype=["float64", "int"]
             )
 
         # pre process X, y
@@ -573,9 +575,10 @@ class BaseWrapper:
         parameters = []
         # reverse the MRO, we want the 1st one to overwrite the nth
         # for class_ in reversed(inspect.getmro(self.__class__)):
-        for p in inspect.signature(self.__class__.__init__).parameters.values():
-            if p.kind not in ARGS_KWARGS_IDENTIFIERS and \
-                    p.name != "self":
+        for p in inspect.signature(
+            self.__class__.__init__
+        ).parameters.values():
+            if p.kind not in ARGS_KWARGS_IDENTIFIERS and p.name != "self":
                 parameters.append(p)
 
         # Extract and sort argument names excluding 'self'
@@ -655,7 +658,7 @@ class BaseWrapper:
     def _get_tags(self):
         collected_tags = {}
         for base_class in reversed(inspect.getmro(self.__class__)):
-            if hasattr(base_class, '_more_tags'):
+            if hasattr(base_class, "_more_tags"):
                 # need the if because mixins might not have _more_tags
                 # but might do redundant work in estimators
                 # (i.e. calling more tags on BaseEstimator multiple times)
@@ -763,7 +766,7 @@ class KerasClassifier(BaseWrapper):
     _scorer = staticmethod(sklearn_accuracy_score)
 
     def _more_tags(self):
-        return {'multilabel': True}
+        return {"multilabel": True}
 
     @staticmethod
     def _pre_process_y(y):
@@ -941,7 +944,7 @@ class KerasClassifier(BaseWrapper):
             )
 
         # basic input checks
-        X = check_array(X, allow_nd=True, dtype=['float64', 'int'])
+        X = check_array(X, allow_nd=True, dtype=["float64", "int"])
 
         # pre process X
         X, _ = self._pre_process_X(X)
@@ -980,7 +983,7 @@ class KerasRegressor(BaseWrapper):
 
     def _post_process_y(self, y):
         """Ensures output is float64 and squeeze."""
-        return np.squeeze(y.astype('float64')), dict()
+        return np.squeeze(y.astype("float64")), dict()
 
     def _pre_process_y(self, y):
         """Split y for multi-output tasks.
@@ -993,7 +996,7 @@ class KerasRegressor(BaseWrapper):
 
         extra_args = {
             "n_outputs_": n_outputs_,
-            "n_outputs_keras_": n_outputs_keras_
+            "n_outputs_keras_": n_outputs_keras_,
         }
 
         y = [y]  # pack into single output list

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -537,8 +537,9 @@ def dynamic_classifier(X, cls_type_, n_classes_, n_outputs_keras_):
         out = [Dense(1, activation="sigmoid")(x1)]
     elif cls_type_ == "multilabel-indicator":
         loss = "binary_crossentropy"
-        out = [Dense(1, activation="sigmoid")(x1) for _ in
-               range(n_outputs_keras_)]
+        out = [
+            Dense(1, activation="sigmoid")(x1) for _ in range(n_outputs_keras_)
+        ]
     elif cls_type_ == "multiclass-multioutput":
         loss = "binary_crossentropy"
         out = [Dense(n, activation="softmax")(x1) for n in n_classes_]
@@ -568,8 +569,7 @@ def dynamic_regressor(X, n_outputs_keras_):
     model = Model([inp], out)
 
     model.compile(
-        optimizer="adam",
-        loss=wrappers.KerasRegressor.root_mean_squared_error,
+        optimizer="adam", loss=wrappers.KerasRegressor.root_mean_squared_error,
     )
     return model
 
@@ -578,8 +578,7 @@ class FullyCompliantClassifier(wrappers.KerasClassifier):
     """A classifier that sets all parameters in __init__ and nothing more."""
 
     def __init__(
-        self, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE,
-        epochs=EPOCHS
+        self, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE, epochs=EPOCHS
     ):
         self.hidden_dim = hidden_dim
         self.batch_size = batch_size
@@ -594,8 +593,7 @@ class FullyCompliantRegressor(wrappers.KerasRegressor):
     """A classifier that sets all parameters in __init__ and nothing more."""
 
     def __init__(
-        self, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE,
-        epochs=EPOCHS
+        self, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE, epochs=EPOCHS
     ):
         self.hidden_dim = hidden_dim
         self.batch_size = batch_size

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -586,7 +586,7 @@ class FullyCompliantClassifier(wrappers.KerasClassifier):
         self.epochs = epochs
         return super().__init__()
 
-    def __call__(self, X, cls_type_, n_classes_, n_outputs_):
+    def __call__(self, X, cls_type_, n_classes_, n_outputs_keras_):
         return dynamic_classifier(X, cls_type_, n_classes_, n_outputs_keras_)
 
 
@@ -602,8 +602,8 @@ class FullyCompliantRegressor(wrappers.KerasRegressor):
         self.epochs = epochs
         return super().__init__()
 
-    def __call__(self, X, n_outputs_):
-        return dynamic_regressor(X, n_outputs_)
+    def __call__(self, X, n_outputs_keras_):
+        return dynamic_regressor(X, n_outputs_keras_)
 
 
 @pytest.mark.xfail(reason="Issues not yet fixed")


### PR DESCRIPTION
Opening to document for future.

Ultimately, I think these wrappers should be able to pass the exhaustive tests in `sklearn.utils.estimator_checks.check_estimator`. In fact, these tests cover a lot of the testing that is currently being done and more.

All of the tests that are currently failing are related to random states. It is my understanding that there is no easy way to set the random state of TF/Keras. The Scikit-Learn tag API defines a parameter `non_deterministic` that if set to `True` I think should make these tests xpass, but it doesn't seem to be checked currently, the tags API is pretty new. More info on tags [here](https://scikit-learn.org/stable/developers/develop.html).

These are the tests that were added:

```python3


def dynamic_classifier(X, cls_type_, n_classes_, n_outputs_keras_):
    """Creates a basic MLP classifier dynamically choosing binary/multiclass
    classification loss and ouput activations.
    """
    n_features = X.shape[1]

    inp = Input(shape=(n_features,))

    x1 = Dense(100)(inp)

    if cls_type_ == "binary":
        loss = "binary_crossentropy"
        out = [Dense(1, activation="sigmoid")(x1)]
    elif cls_type_ == "multilabel-indicator":
        loss = "binary_crossentropy"
        out = [Dense(1, activation="sigmoid")(x1) for _ in
               range(n_outputs_keras_)]
    elif cls_type_ == "multiclass-multioutput":
        loss = "binary_crossentropy"
        out = [Dense(n, activation="softmax")(x1) for n in n_classes_]
    else:
        # multiclass
        loss = "categorical_crossentropy"
        out = [Dense(n_classes_, activation="softmax")(x1)]

    model = Model([inp], out)

    model.compile(optimizer="adam", loss=loss)

    return model


def dynamic_regressor(X, n_outputs_keras_):
    """Creates a basic MLP regressor dynamically.
    """
    n_features = X.shape[1]

    inp = Input(shape=(n_features,))

    x1 = Dense(100)(inp)

    out = [Dense(n_outputs_keras_)(x1)]

    model = Model([inp], out)

    model.compile(
        optimizer="adam",
        loss=wrappers.KerasRegressor.root_mean_squared_error,
    )
    return model


class FullyCompliantClassifier(wrappers.KerasClassifier):
    """A classifier that sets all parameters in __init__ and nothing more."""

    def __init__(
        self, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE,
        epochs=EPOCHS
    ):
        self.hidden_dim = hidden_dim
        self.batch_size = batch_size
        self.epochs = epochs
        return super().__init__()

    def __call__(self, X, cls_type_, n_classes_, n_outputs_keras_):
        return dynamic_classifier(X, cls_type_, n_classes_, n_outputs_keras_)


class FullyCompliantRegressor(wrappers.KerasRegressor):
    """A classifier that sets all parameters in __init__ and nothing more."""

    def __init__(
        self, hidden_dim=HIDDEN_DIM, batch_size=BATCH_SIZE,
        epochs=EPOCHS
    ):
        self.hidden_dim = hidden_dim
        self.batch_size = batch_size
        self.epochs = epochs
        return super().__init__()

    def __call__(self, X, n_outputs_keras_):
        return dynamic_regressor(X, n_outputs_keras_)


@pytest.mark.xfail(reason="Issues not yet fixed")
class TestFullyCompliantWrappers:
    """Tests wrappers that fully comply with the Scikit-Learn
        API by not using kwargs. Testing done with Scikit-Learn's
        internal model validation tool
    """

    @pytest.mark.parametrize(
        "check", check_estimator(FullyCompliantClassifier, generate_only=True)
    )
    def test_fully_compliant_classifier_instance(self, check):
        check[1](check[0])

    @pytest.mark.parametrize(
        "check", check_estimator(FullyCompliantRegressor, generate_only=True)
    )
    def test_fully_compliant_regressor_instance(self, check):
        check[1](check[0])
```

The idea here is to have a dynamic (in terms of input/output size) models that can be fully tested by the scikit-learn test suite.