### PR TITLE
BUG: Fix packing/unpacking of prebuilt model build_fn attribute

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -32,7 +32,7 @@ from tensorflow.python.keras.layers import (
     Flatten,
     Input,
 )
-from tensorflow.python.keras.models import Model, Sequential, clone_model
+from tensorflow.python.keras.models import Model, Sequential
 from tensorflow.python.keras.utils.np_utils import to_categorical
 
 from sklearn_keras_wrap import wrappers
@@ -744,35 +744,6 @@ class TestPrebuiltModel:
 
             estimator = model(build_fn=keras_model)
             check(estimator, loader)
-
-    def test_uncompiled_prebuilt_model_raises_error(self):
-        """Tests that an uncompiled model cannot be used as build_fn param."""
-
-        for config in [
-            "MLPRegressor",
-            "MLPClassifier",
-            "CNNClassifier",
-            "CNNClassifierF",
-        ]:
-            loader, model, build_fn, _ = CONFIG[config]
-            data = loader()
-            x_train, y_train = data.data[:100], data.target[:100]
-
-            n_classes_ = np.unique(y_train).size
-            # make y the same shape as will be used by .fit
-            if config != "MLPRegressor":
-                y_train = to_categorical(y_train)
-                keras_model = build_fn(
-                    X=x_train, n_classes_=n_classes_, n_outputs_=1
-                )
-            else:
-                keras_model = build_fn(X=x_train, n_outputs_=1)
-
-            # clone to simulate uncompiled model
-            keras_model = clone_model(keras_model)
-            estimator = model(build_fn=keras_model)
-            with pytest.raises(ValueError):
-                check(estimator, loader)
 
 
 class FunctionalAPIMultiInputClassifier(KerasClassifier):


### PR DESCRIPTION
Fixes #4 

This adds a violation of the Scikit-Learn API: if `build_fn` is a prebuilt model, it is modified before saving. `Model` instances cannot be pickled directly and hence cannot be saved as an attribute in `__init__`, which is what the Scikit-Learn API expects.